### PR TITLE
feat(dobot-server): TypeScript skeleton — grammY + SQLite + crash boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# dobot-server environment — canonical config (varlock-ready; do-box#7)
+
+# Bot tokens (from @BotFather)
+TELEGRAM_NARRATOR_BOT_TOKEN=1234567890:AAFakeTokenForExamplePurposesOnly123  # required
+TELEGRAM_IDEA_BOT_TOKEN=9876543210:AAFakeIdeaBotTokenForExampleOnly456       # optional (Phase 6)
+
+# DB path (out of repo tree)
+DOBOT_DB_PATH=/home/claude/.local/share/dobot-server/state.db
+
+# Narrator behavior
+NARRATOR_DEFAULT_TONE=serious
+NARRATOR_DEFAULT_SHAPE=origin-story
+NARRATOR_DEFAULT_LENGTH=medium
+NARRATOR_LENGTH_TIMEOUT=20
+NARRATOR_CLAUDE_TIMEOUT=600
+NARRATOR_MDSPEAK_TIMEOUT=600
+NARRATOR_URL_FETCH_TIMEOUT=30
+NARRATOR_DEBOUNCE_MS=2000
+NARRATOR_MAX_CONCURRENT_JOBS=1
+NARRATOR_MAX_JOBS_PER_HOUR=10
+NARRATOR_MAX_DAILY_TTS_USD=5.00
+NARRATOR_MAX_SOURCE_WORDS=8000
+NARRATOR_STORIES_DIR=/home/claude/claudes-world/.world/stories
+NARRATOR_VPS_SHARE_DIR=/home/claude/shared/private/tmp
+NARRATOR_VPS_SHARE_URL_BASE=https://shared.claude.do/private/tmp
+NARRATOR_TMP_DIR=/tmp
+NARRATOR_ALLOWED_USER_IDS=1676859445
+NARRATOR_CLASSIFY_MODEL=claude-haiku-4-5
+NARRATOR_REWRITE_MODEL=claude-sonnet-4-6
+NARRATOR_AGENT_RUN_SCRIPT=/home/claude/claudes-world/agents/narrator/run.sh

--- a/.env.schema
+++ b/.env.schema
@@ -1,0 +1,30 @@
+# dobot-server environment — canonical config (varlock-ready; do-box#7)
+
+# Bot tokens (from @BotFather)
+TELEGRAM_NARRATOR_BOT_TOKEN=         # required
+TELEGRAM_IDEA_BOT_TOKEN=             # optional (Phase 6)
+
+# DB path (out of repo tree)
+DOBOT_DB_PATH=/home/claude/.local/share/dobot-server/state.db
+
+# Narrator behavior
+NARRATOR_DEFAULT_TONE=serious
+NARRATOR_DEFAULT_SHAPE=origin-story
+NARRATOR_DEFAULT_LENGTH=medium
+NARRATOR_LENGTH_TIMEOUT=20
+NARRATOR_CLAUDE_TIMEOUT=600
+NARRATOR_MDSPEAK_TIMEOUT=600
+NARRATOR_URL_FETCH_TIMEOUT=30
+NARRATOR_DEBOUNCE_MS=2000
+NARRATOR_MAX_CONCURRENT_JOBS=1
+NARRATOR_MAX_JOBS_PER_HOUR=10
+NARRATOR_MAX_DAILY_TTS_USD=5.00
+NARRATOR_MAX_SOURCE_WORDS=8000
+NARRATOR_STORIES_DIR=/home/claude/claudes-world/.world/stories
+NARRATOR_VPS_SHARE_DIR=/home/claude/shared/private/tmp
+NARRATOR_VPS_SHARE_URL_BASE=https://shared.claude.do/private/tmp
+NARRATOR_TMP_DIR=/tmp
+NARRATOR_ALLOWED_USER_IDS=1676859445
+NARRATOR_CLASSIFY_MODEL=claude-haiku-4-5
+NARRATOR_REWRITE_MODEL=claude-sonnet-4-6
+NARRATOR_AGENT_RUN_SCRIPT=/home/claude/claudes-world/agents/narrator/run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+state.db*
+*.db-shm
+*.db-wal

--- a/hooks/narrator-session-start.sh
+++ b/hooks/narrator-session-start.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "session-start" >&2
+exit 0

--- a/hooks/narrator-session-stop.sh
+++ b/hooks/narrator-session-stop.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "session-stop" >&2
+exit 0

--- a/hooks/narrator-tool-audit.sh
+++ b/hooks/narrator-tool-audit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "tool-audit $*" >&2
+exit 0

--- a/migrations/001-initial.sql
+++ b/migrations/001-initial.sql
@@ -1,0 +1,48 @@
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS jobs (
+  id              TEXT PRIMARY KEY,
+  handler         TEXT NOT NULL,
+  chat_id         INTEGER NOT NULL,
+  user_id         INTEGER NOT NULL,
+  started_at      INTEGER NOT NULL,
+  completed_at    INTEGER,
+  status          TEXT NOT NULL,
+  source_kind     TEXT,
+  tone            TEXT,
+  shape           TEXT,
+  length          TEXT,
+  output_path     TEXT,
+  subprocess_pid  INTEGER,
+  tts_chars       INTEGER,
+  tts_usd         REAL,
+  stop_reason     TEXT,
+  error           TEXT
+);
+
+CREATE TABLE IF NOT EXISTS pending_length_choices (
+  job_id          TEXT PRIMARY KEY,
+  chat_id         INTEGER NOT NULL,
+  keyboard_msg_id INTEGER NOT NULL,
+  source_tmpfile  TEXT NOT NULL,
+  tone_prefix     TEXT,
+  shape_prefix    TEXT,
+  expires_at      INTEGER NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id)
+);
+
+CREATE TABLE IF NOT EXISTS rate_limits_hourly (
+  id              INTEGER PRIMARY KEY,
+  user_id         INTEGER NOT NULL,
+  handler         TEXT NOT NULL,
+  timestamp       INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rl_hourly_user_ts ON rate_limits_hourly(user_id, timestamp);
+
+CREATE TABLE IF NOT EXISTS rate_limits_daily_spend (
+  id              INTEGER PRIMARY KEY,
+  user_id         INTEGER NOT NULL,
+  timestamp       INTEGER NOT NULL,
+  tts_usd         REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rl_daily_user_ts ON rate_limits_daily_spend(user_id, timestamp);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "dobot-server",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "grammy": "^1.35.0",
+    "better-sqlite3": "^11.0.0",
+    "execa": "^9.0.0",
+    "@opentelemetry/api": "^1.9.0",
+    "dotenv": "^16.0.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,596 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      better-sqlite3:
+        specifier: ^11.0.0
+        version: 11.10.0
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.6.1
+      execa:
+        specifier: ^9.0.0
+        version: 9.6.1
+      grammy:
+        specifier: ^1.35.0
+        version: 1.42.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
+packages:
+
+  '@grammyjs/types@3.26.0':
+    resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  grammy@1.42.0:
+    resolution: {integrity: sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==}
+    engines: {node: ^12.20.0 || >=14.13.1}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@grammyjs/types@3.26.0': {}
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  base64-js@1.5.1: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  chownr@1.1.4: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  detect-libc@2.1.2: {}
+
+  dotenv@16.6.1: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  event-target-shim@5.0.1: {}
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
+  expand-template@2.0.3: {}
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
+  file-uri-to-path@1.0.0: {}
+
+  fs-constants@1.0.0: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
+  github-from-package@0.0.0: {}
+
+  grammy@1.42.0:
+    dependencies:
+      '@grammyjs/types': 3.26.0
+      abort-controller: 3.0.0
+      debug: 4.4.3
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  human-signals@8.0.1: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  isexe@2.0.0: {}
+
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  ms@2.1.3: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parse-ms@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  safe-buffer@5.2.1: {}
+
+  semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-final-newline@4.0.0: {}
+
+  strip-json-comments@2.0.1: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tr46@0.0.3: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  unicorn-magic@0.3.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}
+
+  yoctocolors@2.1.2: {}

--- a/src/bot-factory.ts
+++ b/src/bot-factory.ts
@@ -1,0 +1,5 @@
+import { Bot } from 'grammy';
+
+export function createBot(token: string): Bot {
+  return new Bot(token);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,3 @@
-import * as dotenv from 'dotenv';
-dotenv.config();
-
 function required(name: string): string {
   const val = process.env[name];
   if (!val) throw new Error(`Missing required env var: ${name}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,30 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+function required(name: string): string {
+  const val = process.env[name];
+  if (!val) throw new Error(`Missing required env var: ${name}`);
+  return val;
+}
+
+function optional(name: string, fallback: string): string {
+  return process.env[name] ?? fallback;
+}
+
+export const config = {
+  telegramNarratorBotToken: required('TELEGRAM_NARRATOR_BOT_TOKEN'),
+  telegramIdeaBotToken: process.env['TELEGRAM_IDEA_BOT_TOKEN'],
+  dobotDbPath: optional('DOBOT_DB_PATH', '/home/claude/.local/share/dobot-server/state.db'),
+  narrator: {
+    allowedUserIds: new Set(
+      optional('NARRATOR_ALLOWED_USER_IDS', '').split(',').filter(Boolean).map(Number)
+    ),
+    agentRunScript: optional('NARRATOR_AGENT_RUN_SCRIPT', '/home/claude/claudes-world/agents/narrator/run.sh'),
+    classifyModel: optional('NARRATOR_CLASSIFY_MODEL', 'claude-haiku-4-5'),
+    rewriteModel: optional('NARRATOR_REWRITE_MODEL', 'claude-sonnet-4-6'),
+    claudeTimeout: Number(optional('NARRATOR_CLAUDE_TIMEOUT', '600')) * 1000,
+    maxSourceWords: Number(optional('NARRATOR_MAX_SOURCE_WORDS', '8000')),
+    storiesDir: optional('NARRATOR_STORIES_DIR', '/home/claude/claudes-world/.world/stories'),
+    tmpDir: optional('NARRATOR_TMP_DIR', '/tmp'),
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import { config } from './config.js';
+import { createBot } from './bot-factory.js';
+import { openDatabase } from './state/db.js';
+import { startupSweep } from './state/cleanup.js';
+import { registerHandlers } from './router.js';
+
+async function main(): Promise<void> {
+  const db = openDatabase(config.dobotDbPath);
+  await startupSweep(db);
+
+  const narratorBot = createBot(config.telegramNarratorBotToken);
+
+  // Stub handler — real implementation in #5
+  registerHandlers(narratorBot, {
+    narrator: async (ctx) => {
+      console.log('narrator stub: message from', ctx.from?.id);
+    },
+  });
+
+  // Graceful shutdown
+  process.once('SIGINT', () => narratorBot.stop());
+  process.once('SIGTERM', () => narratorBot.stop());
+
+  console.log('dobot-server listening...');
+  await narratorBot.start();
+}
+
+main().catch((err) => {
+  console.error('Fatal boot error', err);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ async function main(): Promise<void> {
   });
 
   // Graceful shutdown
-  process.once('SIGINT', () => narratorBot.stop());
-  process.once('SIGTERM', () => narratorBot.stop());
+  process.once('SIGINT', () => { narratorBot.stop(); db.close(); });
+  process.once('SIGTERM', () => { narratorBot.stop(); db.close(); });
 
   console.log('dobot-server listening...');
   await narratorBot.start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,11 +18,17 @@ async function main(): Promise<void> {
     },
   });
 
-  // Graceful shutdown — await bot stop before closing DB so in-flight handlers
-  // aren't left with a closed database under their feet.
-  const shutdown = async (): Promise<void> => {
-    await narratorBot.stop();
-    db.close();
+  // Graceful shutdown — idempotent guard ensures concurrent SIGINT+SIGTERM
+  // (e.g. double Ctrl+C) only runs stop/close once.
+  let shutdownPromise: Promise<void> | null = null;
+
+  const shutdown = (): Promise<void> => {
+    if (shutdownPromise) return shutdownPromise;
+    shutdownPromise = (async () => {
+      await narratorBot.stop();
+      db.close();
+    })();
+    return shutdownPromise;
   };
   process.once('SIGINT', () => { shutdown().catch(console.error); });
   process.once('SIGTERM', () => { shutdown().catch(console.error); });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,14 @@ async function main(): Promise<void> {
     },
   });
 
-  // Graceful shutdown
-  process.once('SIGINT', () => { narratorBot.stop(); db.close(); });
-  process.once('SIGTERM', () => { narratorBot.stop(); db.close(); });
+  // Graceful shutdown — await bot stop before closing DB so in-flight handlers
+  // aren't left with a closed database under their feet.
+  const shutdown = async (): Promise<void> => {
+    await narratorBot.stop();
+    db.close();
+  };
+  process.once('SIGINT', () => { shutdown().catch(console.error); });
+  process.once('SIGTERM', () => { shutdown().catch(console.error); });
 
   console.log('dobot-server listening...');
   await narratorBot.start();

--- a/src/lib/otel.ts
+++ b/src/lib/otel.ts
@@ -1,0 +1,5 @@
+import { trace, Tracer } from '@opentelemetry/api';
+
+export function getTracer(name: string): Tracer {
+  return trace.getTracer(name);
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,28 @@
+import { Bot, Context } from 'grammy';
+import { getTracer } from './lib/otel.js';
+
+type Handler = (ctx: Context) => Promise<void>;
+
+export function registerHandlers(bot: Bot, handlers: { narrator: Handler }): void {
+  // Handler crash boundary: every handler wrapped in try/catch
+  bot.on('message', async (ctx) => {
+    const tracer = getTracer('narrator');
+    const span = tracer.startSpan('handler.narrator.message');
+    try {
+      await handlers.narrator(ctx);
+    } catch (err) {
+      console.error('narrator handler threw', err);
+      span.recordException(err as Error);
+      span.setStatus({ code: 2 /* ERROR */ });
+      // Do NOT re-throw — propagation would kill the bot loop
+    } finally {
+      span.end();
+    }
+  });
+}
+
+// Process-level safety net
+process.on('unhandledRejection', (reason) => {
+  console.error('unhandledRejection', reason);
+  // Do not exit — log and continue
+});

--- a/src/state/cleanup.ts
+++ b/src/state/cleanup.ts
@@ -10,26 +10,28 @@ export async function startupSweep(db: Database.Database): Promise<void> {
   db.prepare("UPDATE jobs SET status = 'failed', error = 'orphaned on restart' WHERE status = 'active'").run();
 
   // 3. Delete expired pending choices + unlink temp files
+  const now = Date.now();
   const expired = db.prepare(
     "SELECT source_tmpfile FROM pending_length_choices WHERE expires_at < ?"
-  ).all(Date.now()) as { source_tmpfile: string }[];
+  ).all(now) as { source_tmpfile: string }[];
   for (const row of expired) {
     try { await fs.unlink(row.source_tmpfile); } catch { /* already gone */ }
   }
-  db.prepare("DELETE FROM pending_length_choices WHERE expires_at < ?").run(Date.now());
+  db.prepare("DELETE FROM pending_length_choices WHERE expires_at < ?").run(now);
 
-  // 4. Sweep stale /tmp/narrator-src-* files
+  // 4. Sweep stale narrator-src-* files from tmp dir
   try {
-    const files = (await fs.readdir('/tmp')).filter(f => f.startsWith('narrator-src-'));
+    const tmpDir = process.env['NARRATOR_TMP_DIR'] ?? '/tmp';
+    const files = (await fs.readdir(tmpDir)).filter(f => f.startsWith('narrator-src-'));
     const known = new Set(
       (db.prepare("SELECT source_tmpfile FROM pending_length_choices").all() as { source_tmpfile: string }[])
         .map(r => r.source_tmpfile)
     );
     for (const f of files) {
-      const full = path.join('/tmp', f);
+      const full = path.join(tmpDir, f);
       if (!known.has(full)) {
         try { await fs.unlink(full); } catch {}
       }
     }
-  } catch { /* /tmp not accessible */ }
+  } catch { /* tmp dir not accessible */ }
 }

--- a/src/state/cleanup.ts
+++ b/src/state/cleanup.ts
@@ -1,0 +1,35 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export async function startupSweep(db: Database.Database): Promise<void> {
+  // 1. Null stale subprocess PIDs
+  db.prepare("UPDATE jobs SET subprocess_pid = NULL WHERE status = 'active'").run();
+
+  // 2. Mark orphaned active jobs failed
+  db.prepare("UPDATE jobs SET status = 'failed', error = 'orphaned on restart' WHERE status = 'active'").run();
+
+  // 3. Delete expired pending choices + unlink temp files
+  const expired = db.prepare(
+    "SELECT source_tmpfile FROM pending_length_choices WHERE expires_at < ?"
+  ).all(Date.now()) as { source_tmpfile: string }[];
+  for (const row of expired) {
+    try { await fs.unlink(row.source_tmpfile); } catch { /* already gone */ }
+  }
+  db.prepare("DELETE FROM pending_length_choices WHERE expires_at < ?").run(Date.now());
+
+  // 4. Sweep stale /tmp/narrator-src-* files
+  try {
+    const files = (await fs.readdir('/tmp')).filter(f => f.startsWith('narrator-src-'));
+    const known = new Set(
+      (db.prepare("SELECT source_tmpfile FROM pending_length_choices").all() as { source_tmpfile: string }[])
+        .map(r => r.source_tmpfile)
+    );
+    for (const f of files) {
+      const full = path.join('/tmp', f);
+      if (!known.has(full)) {
+        try { await fs.unlink(full); } catch {}
+      }
+    }
+  } catch { /* /tmp not accessible */ }
+}

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -15,7 +15,11 @@ export function openDatabase(dbPath: string): Database.Database {
   // Run migrations
   const migrationPath = path.resolve(__dirname, '../../migrations/001-initial.sql');
   const sql = fs.readFileSync(migrationPath, 'utf8');
-  db.exec(sql);
+  const version = db.pragma('user_version', { simple: true }) as number;
+  if (version < 1) {
+    db.exec(sql);
+    db.pragma('user_version = 1');
+  }
 
   return db;
 }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -1,0 +1,21 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export function openDatabase(dbPath: string): Database.Database {
+  // Ensure parent directory exists
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+
+  // Run migrations
+  const migrationPath = path.resolve(__dirname, '../../migrations/001-initial.sql');
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+  db.exec(sql);
+
+  return db;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes claudes-world/dobot-server#4
Parent: claudes-world/dobot-server#1

## Summary
- grammY bot skeleton with long-polling
- SQLite/WAL migrations (4 tables: jobs, pending_length_choices, rate_limits_hourly, rate_limits_daily_spend)
- Handler crash boundary in router.ts (try/catch + unhandledRejection net)
- Startup cleanup sweep (orphan job reaping, expired pending choices, stale /tmp files)
- No-op OTEL stub (getTracer → noop tracer)
- Hook stubs (chmod +x, exit 0)
- pnpm `onlyBuiltDependencies: [better-sqlite3]` to enable native build

## Test plan
- [ ] pnpm install && pnpm run build clean
- [ ] pnpm run start connects, logs "dobot-server listening...", exits on SIGTERM
- [ ] sqlite3 .schema shows all 4 tables
- [ ] Send a test message — stub handler logs user id, process stays up