### PR TITLE
feat(narrator): implement handler — text mode, fixed defaults, 12k cap

### DIFF
--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -149,7 +149,7 @@ async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
         '--output-format', 'json',
         '--append-system-prompt-file', opts.sysFile,
         '--model', opts.model,
-        '--disallowedTools', 'Read,Grep',  // prevent prompt injection triggering file reads
+        '--allowedTools', '',  // zero-tool allowlist — narrator rewrite needs no tools; empty allowlist > denylist
       ], {
         input: opts.sourceText,
         extendEnv: false,

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -1,0 +1,161 @@
+import { Context } from 'grammy';
+import Database from 'better-sqlite3';
+import { execa } from 'execa';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { config } from '../config.js';
+
+const SYSTEM_PROMPT_PARTS = [
+  '/home/claude/claudes-world/agents/narrator/.claude/output-styles/narrator.md',
+  '/home/claude/claudes-world/agents/narrator/narrative-writing-guide.md',
+];
+
+const USER_PROMPT = `Rewrite the source provided via stdin as a serious origin-story narrative suitable for text-to-speech playback.
+Target length: medium (approximately 600-900 words of output).
+Respond ONLY with the narrative prose — do not write files, do not include preamble, do not add commentary at the end.`;
+
+interface ClaudeEnvelope {
+  type: string;
+  subtype: string;
+  is_error: boolean;
+  result: string;
+  stop_reason: string;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+export function createNarratorHandler(db: Database.Database) {
+  return async function narratorHandler(ctx: Context): Promise<void> {
+    const userId = ctx.from?.id;
+    if (!userId) return;
+
+    // 1. Filter — silently reject if not in allowlist
+    if (!config.narrator.allowedUserIds.has(userId)) return;
+
+    const sourceText = ctx.message?.text;
+    if (!sourceText) return;
+
+    const jobId = randomUUID();
+    const now = Date.now();
+
+    // 2. Insert jobs row
+    db.prepare(`
+      INSERT INTO jobs (id, handler, chat_id, user_id, started_at, status, source_kind, tone, shape, length)
+      VALUES (?, 'narrator', ?, ?, ?, 'active', 'text', 'serious', 'origin-story', 'medium')
+    `).run(jobId, ctx.chat?.id ?? userId, userId, now);
+
+    let sysTmpFile: string | null = null;
+
+    try {
+      // 3. Build system prompt file
+      sysTmpFile = path.join(config.narrator.tmpDir, `narrator-sys-${jobId}.md`);
+      const parts = await Promise.all(SYSTEM_PROMPT_PARTS.map(p => fs.readFile(p, 'utf8')));
+      await fs.writeFile(sysTmpFile, parts.join('\n\n---\n\n'));
+
+      // 4. Spawn narrator subprocess
+      const result = await spawnNarrator({
+        runScript: config.narrator.agentRunScript,
+        model: config.narrator.rewriteModel,
+        sysFile: sysTmpFile,
+        sourceText,
+        timeout: config.narrator.claudeTimeout,
+      });
+
+      const envelope = result.envelope;
+
+      // 5. Update jobs row
+      db.prepare(`
+        UPDATE jobs SET
+          status = ?,
+          completed_at = ?,
+          stop_reason = ?
+        WHERE id = ?
+      `).run(
+        envelope.is_error ? 'failed' : 'completed',
+        Date.now(),
+        envelope.stop_reason ?? null,
+        jobId
+      );
+
+      if (envelope.is_error) {
+        console.error('narrator: claude returned is_error', envelope);
+        return;
+      }
+
+      const narrative = envelope.result;
+
+      // 6. Log output (delivery wired in #6)
+      const storiesDir = config.narrator.storiesDir;
+      await fs.mkdir(storiesDir, { recursive: true });
+      const slug = new Date().toISOString().replace(/[:.]/g, '-');
+      const outPath = path.join(storiesDir, `${slug}-narrator.narration.md`);
+      await fs.writeFile(outPath, narrative);
+
+      console.log(`narrator: job ${jobId} complete — stop_reason=${envelope.stop_reason}, output written to ${outPath}`);
+
+    } finally {
+      if (sysTmpFile) {
+        try { await fs.unlink(sysTmpFile); } catch { /* already gone */ }
+      }
+    }
+  };
+}
+
+interface SpawnOptions {
+  runScript: string;
+  model: string;
+  sysFile: string;
+  sourceText: string;
+  timeout: number;
+}
+
+interface SpawnResult {
+  envelope: ClaudeEnvelope;
+  retried: boolean;
+}
+
+async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
+  let retried = false;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const proc = await execa(opts.runScript, [
+        '-p', USER_PROMPT,
+        '--output-format', 'json',
+        '--append-system-prompt-file', opts.sysFile,
+        '--model', opts.model,
+      ], {
+        input: opts.sourceText,
+        env: {
+          PATH: process.env['PATH'] ?? '/usr/local/bin:/usr/bin:/bin',
+          HOME: process.env['HOME'] ?? '/home/claude',
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '12000',
+        },
+        timeout: opts.timeout,
+        cleanup: true,
+        killSignal: 'SIGKILL',
+      });
+
+      const envelope: ClaudeEnvelope = JSON.parse(proc.stdout);
+      return { envelope, retried };
+
+    } catch (err: unknown) {
+      const msg = String(err);
+      const isAuthError = msg.includes('401') || msg.includes('authentication') || msg.includes('OAuth');
+
+      if (attempt === 0 && isAuthError) {
+        retried = true;
+        console.warn('narrator: OAuth error on attempt 1, retrying once...');
+        await new Promise(r => setTimeout(r, 2000));
+        continue;
+      }
+
+      throw err;
+    }
+  }
+
+  throw new Error('narrator: exhausted retries');
+}

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -96,6 +96,14 @@ export function createNarratorHandler(db: Database.Database) {
 
       console.log(`narrator: job ${jobId} complete — stop_reason=${envelope.stop_reason}, output written to ${outPath}`);
 
+    } catch (err: unknown) {
+      // Update job row to failed — any unhandled throw reaches here
+      try {
+        db.prepare(`
+          UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ?
+        `).run(Date.now(), String(err), jobId);
+      } catch { /* DB may be closing */ }
+      throw err;  // re-throw so router crash boundary logs it
     } finally {
       if (sysTmpFile) {
         try { await fs.unlink(sysTmpFile); } catch { /* already gone */ }
@@ -140,7 +148,17 @@ async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
         killSignal: 'SIGKILL',
       });
 
-      const envelope: ClaudeEnvelope = JSON.parse(proc.stdout);
+      let envelope: ClaudeEnvelope;
+      try {
+        const parsed = JSON.parse(proc.stdout) as Record<string, unknown>;
+        // Runtime shape check — ensure critical fields are present
+        if (typeof parsed['is_error'] !== 'boolean' || typeof parsed['result'] !== 'string') {
+          throw new Error(`Malformed Claude envelope — missing is_error or result. stdout: ${proc.stdout.slice(0, 200)}`);
+        }
+        envelope = parsed as unknown as ClaudeEnvelope;
+      } catch (parseErr) {
+        throw new Error(`Failed to parse Claude output: ${String(parseErr)}. stdout: ${proc.stdout.slice(0, 200)}`);
+      }
       return { envelope, retried };
 
     } catch (err: unknown) {

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -38,6 +38,13 @@ export function createNarratorHandler(db: Database.Database) {
     const sourceText = ctx.message?.text;
     if (!sourceText) return;
 
+    // Word-count guard — reject oversized input before spawning subprocess
+    const wordCount = sourceText.split(/\s+/).filter(Boolean).length;
+    if (wordCount > config.narrator.maxSourceWords) {
+      console.log(`narrator: rejected oversized input (${wordCount} words) from user ${userId}`);
+      return;
+    }
+
     const jobId = randomUUID();
     const now = Date.now();
 
@@ -142,6 +149,7 @@ async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
         '--output-format', 'json',
         '--append-system-prompt-file', opts.sysFile,
         '--model', opts.model,
+        '--disallowedTools', 'Read,Grep',  // prevent prompt injection triggering file reads
       ], {
         input: opts.sourceText,
         extendEnv: false,

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -129,6 +129,7 @@ async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
         '--model', opts.model,
       ], {
         input: opts.sourceText,
+        extendEnv: false,
         env: {
           PATH: process.env['PATH'] ?? '/usr/local/bin:/usr/bin:/bin',
           HOME: process.env['HOME'] ?? '/home/claude',

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -66,33 +66,40 @@ export function createNarratorHandler(db: Database.Database) {
 
       const envelope = result.envelope;
 
-      // 5. Update jobs row
-      db.prepare(`
-        UPDATE jobs SET
-          status = ?,
-          completed_at = ?,
-          stop_reason = ?
-        WHERE id = ?
-      `).run(
-        envelope.is_error ? 'failed' : 'completed',
-        Date.now(),
-        envelope.stop_reason ?? null,
-        jobId
-      );
-
+      // 5. Handle error envelope — mark failed and write error column
       if (envelope.is_error) {
         console.error('narrator: claude returned is_error', envelope);
+        try {
+          db.prepare(`UPDATE jobs SET status = 'failed', completed_at = ?, stop_reason = ?, error = ? WHERE id = ?`)
+            .run(Date.now(), envelope.stop_reason ?? null, envelope.result.slice(0, 500), jobId);
+        } catch { /* DB may be closing */ }
+        // Write error text so DB is diagnosable without log scraping
         return;
       }
 
       const narrative = envelope.result;
 
-      // 6. Log output (delivery wired in #6)
+      // 6. Write file first — then update DB so a crash between the two leaves no phantom completed row
       const storiesDir = config.narrator.storiesDir;
       await fs.mkdir(storiesDir, { recursive: true });
       const slug = new Date().toISOString().replace(/[:.]/g, '-');
-      const outPath = path.join(storiesDir, `${slug}-narrator.narration.md`);
+      // Include jobId prefix to prevent same-ms filename collision for concurrent jobs
+      const outPath = path.join(storiesDir, `${slug}-${jobId.slice(0, 8)}-narrator.narration.md`);
       await fs.writeFile(outPath, narrative);
+
+      db.prepare(`
+        UPDATE jobs SET
+          status = 'completed',
+          completed_at = ?,
+          stop_reason = ?,
+          output_path = ?
+        WHERE id = ?
+      `).run(
+        Date.now(),
+        envelope.stop_reason ?? null,
+        outPath,
+        jobId
+      );
 
       console.log(`narrator: job ${jobId} complete — stop_reason=${envelope.stop_reason}, output written to ${outPath}`);
 
@@ -139,6 +146,8 @@ async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
         input: opts.sourceText,
         extendEnv: false,
         env: {
+          // OAuth-only per ADR 0013 — ANTHROPIC_API_KEY intentionally excluded.
+          // run.sh sets CLAUDE_CONFIG_DIR pointing to .credentials.json symlink.
           PATH: process.env['PATH'] ?? '/usr/local/bin:/usr/bin:/bin',
           HOME: process.env['HOME'] ?? '/home/claude',
           CLAUDE_CODE_MAX_OUTPUT_TOKENS: '12000',

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createBot } from './bot-factory.js';
 import { openDatabase } from './state/db.js';
 import { startupSweep } from './state/cleanup.js';
 import { registerHandlers } from './router.js';
+import { createNarratorHandler } from './handlers/narrator.js';
 
 async function main(): Promise<void> {
   const db = openDatabase(config.dobotDbPath);
@@ -11,11 +12,8 @@ async function main(): Promise<void> {
 
   const narratorBot = createBot(config.telegramNarratorBotToken);
 
-  // Stub handler — real implementation in #5
   registerHandlers(narratorBot, {
-    narrator: async (ctx) => {
-      console.log('narrator stub: message from', ctx.from?.id);
-    },
+    narrator: createNarratorHandler(db),
   });
 
   // Graceful shutdown — idempotent guard ensures concurrent SIGINT+SIGTERM


### PR DESCRIPTION
## Summary

- Implements `src/handlers/narrator.ts` — full narrator handler with SQLite job tracking, system prompt assembly, execa subprocess spawn with auth retry, and output written to `storiesDir`
- Replaces stub in `src/index.ts` with `createNarratorHandler(db)`
- Env allowlist enforced: only `PATH`, `HOME`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS` passed to subprocess
- `stop_reason=max_tokens` is non-fatal: logged + output written anyway (delivery caption flag deferred to #6)
- Auth retry: once, only on 401/authentication/OAuth errors

Closes claudes-world/dobot-server#5
Parent: claudes-world/dobot-server#1