### PR TITLE
feat(otel): wire OTEL instrumentation — stdout exporter, rewrite.sonnet span

### DIFF
--- a/hooks/narrator-session-start.sh
+++ b/hooks/narrator-session-start.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "session-start" >&2
+echo "{\"name\":\"session.narrator.start\",\"ts\":$(date +%s%3N),\"job_id\":\"${NARRATOR_JOB_ID:-unknown}\"}" >> /tmp/otel-narrator.jsonl 2>/dev/null || true
 exit 0

--- a/hooks/narrator-session-start.sh
+++ b/hooks/narrator-session-start.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+command -v jq &>/dev/null || exit 0
 jq -n --arg id "${NARRATOR_JOB_ID:-unknown}" \
    --argjson ts "$(date +%s%3N)" \
    '{name: "session.narrator.start", ts: $ts, job_id: $id}' \

--- a/hooks/narrator-session-start.sh
+++ b/hooks/narrator-session-start.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
-echo "{\"name\":\"session.narrator.start\",\"ts\":$(date +%s%3N),\"job_id\":\"${NARRATOR_JOB_ID:-unknown}\"}" >> /tmp/otel-narrator.jsonl 2>/dev/null || true
+jq -n --arg id "${NARRATOR_JOB_ID:-unknown}" \
+   --argjson ts "$(date +%s%3N)" \
+   '{name: "session.narrator.start", ts: $ts, job_id: $id}' \
+   >> /tmp/otel-narrator.jsonl 2>/dev/null || true
 exit 0

--- a/hooks/narrator-session-stop.sh
+++ b/hooks/narrator-session-stop.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "session-stop" >&2
+echo "{\"name\":\"session.narrator.stop\",\"ts\":$(date +%s%3N),\"job_id\":\"${NARRATOR_JOB_ID:-unknown}\"}" >> /tmp/otel-narrator.jsonl 2>/dev/null || true
 exit 0

--- a/hooks/narrator-session-stop.sh
+++ b/hooks/narrator-session-stop.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+command -v jq &>/dev/null || exit 0
 jq -n --arg id "${NARRATOR_JOB_ID:-unknown}" \
    --argjson ts "$(date +%s%3N)" \
    '{name: "session.narrator.stop", ts: $ts, job_id: $id}' \

--- a/hooks/narrator-session-stop.sh
+++ b/hooks/narrator-session-stop.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
-echo "{\"name\":\"session.narrator.stop\",\"ts\":$(date +%s%3N),\"job_id\":\"${NARRATOR_JOB_ID:-unknown}\"}" >> /tmp/otel-narrator.jsonl 2>/dev/null || true
+jq -n --arg id "${NARRATOR_JOB_ID:-unknown}" \
+   --argjson ts "$(date +%s%3N)" \
+   '{name: "session.narrator.stop", ts: $ts, job_id: $id}' \
+   >> /tmp/otel-narrator.jsonl 2>/dev/null || true
 exit 0

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "better-sqlite3": "^11.0.0",
     "execa": "^9.0.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@opentelemetry/sdk-trace-node": "^1.30.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "dotenv": "^16.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
+      '@opentelemetry/resources':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.40.0
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
@@ -42,6 +54,56 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -328,6 +390,52 @@ snapshots:
   '@grammyjs/types@3.26.0': {}
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      semver: 7.7.4
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { config } from '../config.js';
+import { getTracer, withSpan } from '../lib/otel.js';
 
 const SYSTEM_PROMPT_PARTS = [
   '/home/claude/claudes-world/agents/narrator/.claude/output-styles/narrator.md',
@@ -26,6 +27,8 @@ interface ClaudeEnvelope {
     output_tokens: number;
   };
 }
+
+const tracer = getTracer('narrator');
 
 export function createNarratorHandler(db: Database.Database) {
   return async function narratorHandler(ctx: Context): Promise<void> {
@@ -62,13 +65,30 @@ export function createNarratorHandler(db: Database.Database) {
       const parts = await Promise.all(SYSTEM_PROMPT_PARTS.map(p => fs.readFile(p, 'utf8')));
       await fs.writeFile(sysTmpFile, parts.join('\n\n---\n\n'));
 
-      // 4. Spawn narrator subprocess
-      const result = await spawnNarrator({
-        runScript: config.narrator.agentRunScript,
-        model: config.narrator.rewriteModel,
-        sysFile: sysTmpFile,
-        sourceText,
-        timeout: config.narrator.claudeTimeout,
+      // 4. Spawn narrator subprocess — wrapped in OTEL span
+      const result = await withSpan(tracer, 'rewrite.sonnet', {
+        job_id: jobId,
+        chat_id: String(ctx.chat?.id ?? userId),
+        user_id: String(userId),
+        handler_name: 'narrator',
+        claude_model: config.narrator.rewriteModel,
+      }, async (span) => {
+        const r = await spawnNarrator({
+          runScript: config.narrator.agentRunScript,
+          model: config.narrator.rewriteModel,
+          sysFile: sysTmpFile!,
+          sourceText,
+          timeout: config.narrator.claudeTimeout,
+        });
+        span.setAttribute('claude_stop_reason', r.envelope.stop_reason ?? 'unknown');
+        const usage = (r.envelope as unknown as Record<string, unknown>)['usage'] as
+          | { input_tokens?: number; output_tokens?: number }
+          | undefined;
+        if (usage) {
+          span.setAttribute('claude_tokens_in', usage.input_tokens ?? 0);
+          span.setAttribute('claude_tokens_out', usage.output_tokens ?? 0);
+        }
+        return r;
       });
 
       const envelope = result.envelope;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import './lib/otel.js';
 import 'dotenv/config';
 import { config } from './config.js';
 import { createBot } from './bot-factory.js';

--- a/src/lib/otel.ts
+++ b/src/lib/otel.ts
@@ -2,7 +2,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
 import { Resource } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
-import { trace, Tracer, Span, SpanStatusCode } from '@opentelemetry/api';
+import { context, trace, Tracer, Span, SpanStatusCode } from '@opentelemetry/api';
 
 const provider = new NodeTracerProvider({
   resource: new Resource({
@@ -26,7 +26,7 @@ export async function withSpan<T>(
 ): Promise<T> {
   const span = tracer.startSpan(name, { attributes: attrs });
   try {
-    return await fn(span);
+    return await context.with(trace.setSpan(context.active(), span), () => fn(span));
   } catch (err) {
     span.recordException(err as Error);
     span.setStatus({ code: SpanStatusCode.ERROR });

--- a/src/lib/otel.ts
+++ b/src/lib/otel.ts
@@ -1,5 +1,37 @@
-import { trace, Tracer } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { Resource } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { trace, Tracer, Span, SpanStatusCode } from '@opentelemetry/api';
+
+const provider = new NodeTracerProvider({
+  resource: new Resource({
+    [ATTR_SERVICE_NAME]: 'dobot-server',
+  }),
+});
+
+provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+provider.register();
 
 export function getTracer(name: string): Tracer {
   return trace.getTracer(name);
+}
+
+// Convenience wrapper — every span must be paired with span.end()
+export async function withSpan<T>(
+  tracer: Tracer,
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: (span: Span) => Promise<T>
+): Promise<T> {
+  const span = tracer.startSpan(name, { attributes: attrs });
+  try {
+    return await fn(span);
+  } catch (err) {
+    span.recordException(err as Error);
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw err;
+  } finally {
+    span.end();
+  }
 }


### PR DESCRIPTION
## Summary

- Replaces no-op `otel.ts` stub with `NodeTracerProvider` + `ConsoleSpanExporter` (spans emit JSON to stdout)
- Adds `withSpan<T>` helper with try/finally lifecycle guarantee (no span leaks)
- Wraps `spawnNarrator` call in `rewrite.sonnet` span with `job_id`, `user_id`, `chat_id`, token counts, stop_reason
- Adds `import './lib/otel.js'` at top of `index.ts` so provider registers before any tracer is acquired
- Updates `hooks/narrator-session-{start,stop}.sh` to append JSON spans to `/tmp/otel-narrator.jsonl`
- Adds `@opentelemetry/sdk-trace-{base,node}`, `@opentelemetry/resources`, `@opentelemetry/semantic-conventions`

Closes claudes-world/dobot-server#7
Parent: claudes-world/dobot-server#1

## Sample span output

```json
{
  "resource": {
    "attributes": {
      "service.name": "dobot-server",
      "telemetry.sdk.language": "nodejs",
      "telemetry.sdk.name": "opentelemetry",
      "telemetry.sdk.version": "1.30.1"
    }
  },
  "instrumentationScope": { "name": "narrator" },
  "name": "rewrite.sonnet",
  "traceId": "f86262c610f403e8bbfe9ca6e2dc8a93",
  "id": "87fa2ded1c96301d",
  "timestamp": 1776237222514000,
  "duration": 263.371,
  "attributes": {
    "job_id": "...",
    "chat_id": "...",
    "user_id": "...",
    "handler_name": "narrator",
    "claude_model": "claude-sonnet-4-5",
    "claude_stop_reason": "end_turn",
    "claude_tokens_in": 1234,
    "claude_tokens_out": 567
  },
  "status": { "code": 0 }
}
```

## Notes

- No SQLite trace table — spans go to stdout only (per spec)
- `withSpan` uses `SpanStatusCode.ERROR` (not numeric `2`) for error status
- `narrator.ts` changes will conflict with #6 delivery changes when #6 merges — second PR just needs rebase