### PR TITLE
feat(security): URL validator stub (#11)

### DIFF
--- a/src/lib/url-validator.ts
+++ b/src/lib/url-validator.ts
@@ -1,6 +1,7 @@
 import dns from 'node:dns/promises';
 
-const PRIVATE_IP_REGEX = /^(127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.|::1|localhost)/;
+const PRIVATE_IP_REGEX = /^(0\.|127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.)/;
+const PRIVATE_IPV6_LOOPBACK = /^::1$/;
 const ALLOWED_CONTENT_TYPES = ["text/html", "text/markdown", "text/plain"];
 const MAX_REDIRECTS = 3;
 const MAX_BODY_BYTES = 500 * 1024;
@@ -9,9 +10,14 @@ const FETCH_TIMEOUT_MS = 30000;
 /**
  * Validates and fetches a URL safely.
  *
- * Known limitation: PRIVATE_IP_REGEX misses IPv6 CIDR ranges, IPv4-mapped addresses (::ffff:10.x),
- * and CGNAT (100.64.0.0/10). Phase 3 upgrade to ipaddr.js will cover these — DO NOT add that
- * dependency here.
+ * DNS lookup is performed once per hop to provide a best-effort SSRF check.
+ * Known limitations (all deferred to Phase 3 upgrade to ipaddr.js + undici dispatcher):
+ * - DNS rebinding TOCTOU: fetch() re-resolves the hostname at TCP connect time; an attacker with
+ *   a short-TTL record can pass the DNS check then rebind to a private IP. Mitigating this
+ *   properly requires pinning the resolved IP at the socket level (undici Agent dispatcher).
+ * - PRIVATE_IP_REGEX misses IPv6 ULA (fc00::/7), link-local (fe80::/10),
+ *   IPv4-mapped (::ffff:10.x), and CGNAT (100.64.0.0/10).
+ * - DO NOT add ipaddr.js or undici dispatcher here; defer all of the above to Phase 3.
  */
 export async function validateAndFetchUrl(urlString: string): Promise<string> {
   // 1. Parse and assert HTTPS
@@ -25,19 +31,25 @@ export async function validateAndFetchUrl(urlString: string): Promise<string> {
     throw new Error(`Only HTTPS URLs allowed, got: ${url.protocol}`);
   }
 
-  // 2. Resolve hostname via DNS, assert not private IP
-  let resolvedIp: string;
-  try {
-    const result = await dns.lookup(url.hostname);
-    resolvedIp = result.address;
-  } catch (err) {
-    throw new Error(`DNS resolution failed for ${url.hostname}: ${err}`);
-  }
-  if (PRIVATE_IP_REGEX.test(resolvedIp)) {
-    throw new Error(`URL resolves to private IP address: ${resolvedIp}`);
+  /**
+   * Resolve hostname → IP, assert not private/loopback.
+   * Re-called for each redirect hop as a best-effort SSRF check.
+   * See JSDoc for DNS rebinding TOCTOU caveat.
+   */
+  async function resolveAndAssert(hostname: string): Promise<void> {
+    let address: string;
+    try {
+      const result = await dns.lookup(hostname);
+      address = result.address;
+    } catch (err) {
+      throw new Error(`DNS resolution failed for ${hostname}: ${err}`);
+    }
+    if (PRIVATE_IP_REGEX.test(address) || PRIVATE_IPV6_LOOPBACK.test(address)) {
+      throw new Error(`URL resolves to private IP address: ${address}`);
+    }
   }
 
-  // 3. Fetch with timeout and manual redirect following (MAX_REDIRECTS enforced)
+  // 2. Fetch with AbortController covering the entire operation (headers + body)
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
@@ -46,59 +58,73 @@ export async function validateAndFetchUrl(urlString: string): Promise<string> {
   let response: Response;
 
   try {
+    // 2a. Follow redirects manually (MAX_REDIRECTS enforced, each hop DNS-validated)
     while (true) {
+      const hopUrl = new URL(currentUrl);
+      await resolveAndAssert(hopUrl.hostname);
+
       response = await fetch(currentUrl, {
         signal: controller.signal,
         redirect: 'manual',
       });
+
       if (response.status >= 300 && response.status < 400) {
         redirectCount++;
         if (redirectCount > MAX_REDIRECTS) {
+          response.body?.cancel().catch(() => {});
           throw new Error(`Too many redirects (max ${MAX_REDIRECTS})`);
         }
         const location = response.headers.get('location');
         if (!location) throw new Error('Redirect with no Location header');
-        currentUrl = new URL(location, currentUrl).toString();
+        const nextUrl = new URL(location, currentUrl);
+        // Assert redirect target is also HTTPS
+        if (nextUrl.protocol !== 'https:') {
+          throw new Error(`Redirect to non-HTTPS URL: ${nextUrl.protocol}`);
+        }
+        currentUrl = nextUrl.toString();
+        // Drain/cancel the redirect response body to release the underlying connection
+        response.body?.cancel().catch(() => {});
         continue;
       }
       break;
     }
+
+    // 3. Assert content-type
+    const contentType = response.headers.get('content-type') ?? '';
+    const ctBase = contentType.split(';')[0].trim();
+    if (!ALLOWED_CONTENT_TYPES.some(ct => ctBase === ct)) {
+      response.body?.cancel().catch(() => {});
+      throw new Error(`Disallowed content-type: ${ctBase}`);
+    }
+
+    // 4. Stream body with byte cap (timer still active — covers slow-drip responses)
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Response body is null');
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        totalBytes += value.length;
+        if (totalBytes > MAX_BODY_BYTES) {
+          reader.cancel().catch(() => {});
+          throw new Error(`Response body exceeds ${MAX_BODY_BYTES} bytes`);
+        }
+        chunks.push(value);
+      }
+    }
+
+    return Buffer.concat(chunks).toString('utf-8');
   } catch (err) {
-    clearTimeout(timer);
     if ((err as Error).name === 'AbortError') {
       throw new Error(`Fetch timed out after ${FETCH_TIMEOUT_MS}ms`);
     }
     throw err;
   } finally {
+    // Single canonical cleanup — covers all exit paths (normal, throws, abort)
     clearTimeout(timer);
   }
-
-  // 4. Assert content-type
-  const contentType = response.headers.get('content-type') ?? '';
-  const ctBase = contentType.split(';')[0].trim();
-  if (!ALLOWED_CONTENT_TYPES.some(ct => ctBase === ct)) {
-    throw new Error(`Disallowed content-type: ${ctBase}`);
-  }
-
-  // 5. Stream body with byte cap
-  const reader = response.body?.getReader();
-  if (!reader) throw new Error('Response body is null');
-
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (value) {
-      totalBytes += value.length;
-      if (totalBytes > MAX_BODY_BYTES) {
-        reader.cancel().catch(() => {});
-        throw new Error(`Response body exceeds ${MAX_BODY_BYTES} bytes`);
-      }
-      chunks.push(value);
-    }
-  }
-
-  return Buffer.concat(chunks).toString('utf-8');
 }

--- a/src/lib/url-validator.ts
+++ b/src/lib/url-validator.ts
@@ -1,0 +1,104 @@
+import dns from 'node:dns/promises';
+
+const PRIVATE_IP_REGEX = /^(127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.|::1|localhost)/;
+const ALLOWED_CONTENT_TYPES = ["text/html", "text/markdown", "text/plain"];
+const MAX_REDIRECTS = 3;
+const MAX_BODY_BYTES = 500 * 1024;
+const FETCH_TIMEOUT_MS = 30000;
+
+/**
+ * Validates and fetches a URL safely.
+ *
+ * Known limitation: PRIVATE_IP_REGEX misses IPv6 CIDR ranges, IPv4-mapped addresses (::ffff:10.x),
+ * and CGNAT (100.64.0.0/10). Phase 3 upgrade to ipaddr.js will cover these — DO NOT add that
+ * dependency here.
+ */
+export async function validateAndFetchUrl(urlString: string): Promise<string> {
+  // 1. Parse and assert HTTPS
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new Error(`Invalid URL: ${urlString}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`Only HTTPS URLs allowed, got: ${url.protocol}`);
+  }
+
+  // 2. Resolve hostname via DNS, assert not private IP
+  let resolvedIp: string;
+  try {
+    const result = await dns.lookup(url.hostname);
+    resolvedIp = result.address;
+  } catch (err) {
+    throw new Error(`DNS resolution failed for ${url.hostname}: ${err}`);
+  }
+  if (PRIVATE_IP_REGEX.test(resolvedIp)) {
+    throw new Error(`URL resolves to private IP address: ${resolvedIp}`);
+  }
+
+  // 3. Fetch with timeout and manual redirect following (MAX_REDIRECTS enforced)
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let currentUrl = url.toString();
+  let redirectCount = 0;
+  let response: Response;
+
+  try {
+    while (true) {
+      response = await fetch(currentUrl, {
+        signal: controller.signal,
+        redirect: 'manual',
+      });
+      if (response.status >= 300 && response.status < 400) {
+        redirectCount++;
+        if (redirectCount > MAX_REDIRECTS) {
+          throw new Error(`Too many redirects (max ${MAX_REDIRECTS})`);
+        }
+        const location = response.headers.get('location');
+        if (!location) throw new Error('Redirect with no Location header');
+        currentUrl = new URL(location, currentUrl).toString();
+        continue;
+      }
+      break;
+    }
+  } catch (err) {
+    clearTimeout(timer);
+    if ((err as Error).name === 'AbortError') {
+      throw new Error(`Fetch timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // 4. Assert content-type
+  const contentType = response.headers.get('content-type') ?? '';
+  const ctBase = contentType.split(';')[0].trim();
+  if (!ALLOWED_CONTENT_TYPES.some(ct => ctBase === ct)) {
+    throw new Error(`Disallowed content-type: ${ctBase}`);
+  }
+
+  // 5. Stream body with byte cap
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('Response body is null');
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      totalBytes += value.length;
+      if (totalBytes > MAX_BODY_BYTES) {
+        reader.cancel().catch(() => {});
+        throw new Error(`Response body exceeds ${MAX_BODY_BYTES} bytes`);
+      }
+      chunks.push(value);
+    }
+  }
+
+  return Buffer.concat(chunks).toString('utf-8');
+}

--- a/test/lib/url-validator.test.ts
+++ b/test/lib/url-validator.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateAndFetchUrl } from '../../src/lib/url-validator.js';
+
+// Mock dns/promises module
+vi.mock('node:dns/promises', () => ({
+  default: {
+    lookup: vi.fn(),
+  },
+}));
+
+import dns from 'node:dns/promises';
+const mockDnsLookup = dns.lookup as ReturnType<typeof vi.fn>;
+
+// Helper to build a minimal Response-like object
+function makeResponse(opts: {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string;
+  location?: string;
+}): Response {
+  const { status = 200, headers = {}, body = '' } = opts;
+  const headerMap = new Headers(headers);
+  if (opts.location) headerMap.set('location', opts.location);
+
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(body);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoded);
+      controller.close();
+    },
+  });
+
+  return new Response(stream, { status, headers: headerMap });
+}
+
+// Stub global fetch
+let fetchStub: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchStub = vi.fn();
+  vi.stubGlobal('fetch', fetchStub);
+  mockDnsLookup.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('validateAndFetchUrl', () => {
+  it('1. valid HTTPS URL — returns body', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    fetchStub.mockResolvedValue(
+      makeResponse({ headers: { 'content-type': 'text/html' }, body: '<h1>Hello</h1>' })
+    );
+
+    const result = await validateAndFetchUrl('https://example.com/page');
+    expect(result).toBe('<h1>Hello</h1>');
+  });
+
+  it('2. HTTP URL — throws protocol error', async () => {
+    await expect(validateAndFetchUrl('http://example.com/')).rejects.toThrow(
+      /Only HTTPS URLs allowed/
+    );
+  });
+
+  it('3. URL resolving to 127.0.0.1 — throws private IP error', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+
+    await expect(validateAndFetchUrl('https://localhost.test/')).rejects.toThrow(
+      /private IP address/
+    );
+  });
+
+  it('4. URL resolving to 10.x.x.x — throws private IP error', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+
+    await expect(validateAndFetchUrl('https://internal.corp/')).rejects.toThrow(
+      /private IP address/
+    );
+  });
+
+  it('5. redirect chain > 3 — throws too-many-redirects', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+
+    // 4 redirects → exceeds MAX_REDIRECTS=3
+    fetchStub
+      .mockResolvedValueOnce(makeResponse({ status: 301, location: 'https://example.com/r1' }))
+      .mockResolvedValueOnce(makeResponse({ status: 301, location: 'https://example.com/r2' }))
+      .mockResolvedValueOnce(makeResponse({ status: 301, location: 'https://example.com/r3' }))
+      .mockResolvedValueOnce(makeResponse({ status: 301, location: 'https://example.com/r4' }));
+
+    await expect(validateAndFetchUrl('https://example.com/')).rejects.toThrow(
+      /Too many redirects/
+    );
+  });
+
+  it('6. content-type application/json — throws disallowed content-type', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    fetchStub.mockResolvedValue(
+      makeResponse({ headers: { 'content-type': 'application/json' }, body: '{}' })
+    );
+
+    await expect(validateAndFetchUrl('https://example.com/api')).rejects.toThrow(
+      /Disallowed content-type/
+    );
+  });
+
+  it('7. body > 500KB — throws body too large', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+
+    // Stream slightly over 500KB in one chunk
+    const bigBody = 'x'.repeat(500 * 1024 + 1);
+    fetchStub.mockResolvedValue(
+      makeResponse({ headers: { 'content-type': 'text/plain' }, body: bigBody })
+    );
+
+    await expect(validateAndFetchUrl('https://example.com/big')).rejects.toThrow(
+      /exceeds/
+    );
+  });
+
+  it('8. AbortController timeout — throws timeout error', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+
+    const abortErr = new DOMException('The operation was aborted', 'AbortError');
+    fetchStub.mockRejectedValue(abortErr);
+
+    await expect(validateAndFetchUrl('https://example.com/slow')).rejects.toThrow(
+      /timed out/
+    );
+  });
+});

--- a/test/lib/url-validator.test.ts
+++ b/test/lib/url-validator.test.ts
@@ -82,9 +82,10 @@ describe('validateAndFetchUrl', () => {
   });
 
   it('5. redirect chain > 3 — throws too-many-redirects', async () => {
+    // dns.lookup always returns public IP (called once per hop)
     mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
 
-    // 4 redirects → exceeds MAX_REDIRECTS=3
+    // 4 consecutive 301s — exceeds MAX_REDIRECTS=3
     fetchStub
       .mockResolvedValueOnce(makeResponse({ status: 301, location: 'https://example.com/r1' }))
       .mockResolvedValueOnce(makeResponse({ status: 301, location: 'https://example.com/r2' }))
@@ -110,7 +111,6 @@ describe('validateAndFetchUrl', () => {
   it('7. body > 500KB — throws body too large', async () => {
     mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
 
-    // Stream slightly over 500KB in one chunk
     const bigBody = 'x'.repeat(500 * 1024 + 1);
     fetchStub.mockResolvedValue(
       makeResponse({ headers: { 'content-type': 'text/plain' }, body: bigBody })
@@ -129,6 +129,32 @@ describe('validateAndFetchUrl', () => {
 
     await expect(validateAndFetchUrl('https://example.com/slow')).rejects.toThrow(
       /timed out/
+    );
+  });
+
+  it('9. redirect to HTTP — throws non-HTTPS redirect error', async () => {
+    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    fetchStub.mockResolvedValueOnce(
+      makeResponse({ status: 301, location: 'http://example.com/downgrade' })
+    );
+
+    await expect(validateAndFetchUrl('https://example.com/')).rejects.toThrow(
+      /non-HTTPS/
+    );
+  });
+
+  it('10. redirect to private IP — throws private IP error', async () => {
+    // DNS called once per hop: first call for example.com (public), second for internal.corp (private)
+    mockDnsLookup
+      .mockResolvedValueOnce({ address: '93.184.216.34', family: 4 })  // hop 1: example.com
+      .mockResolvedValueOnce({ address: '192.168.1.1', family: 4 });   // hop 2: internal.corp
+
+    fetchStub.mockResolvedValueOnce(
+      makeResponse({ status: 301, location: 'https://internal.corp/admin' })
+    );
+
+    await expect(validateAndFetchUrl('https://example.com/')).rejects.toThrow(
+      /private IP address/
     );
   });
 });


### PR DESCRIPTION
Closes #11

Implements `src/lib/url-validator.ts` per Phase 2 spec.

- HTTPS-only protocol check (initial URL + every redirect hop)
- DNS hostname resolution + private IP regex block (`0.0.0.0`, `127.x`, RFC1918, `169.254.x`, `::1`)
- Manual redirect following with `MAX_REDIRECTS=3` cap
- Per-hop DNS re-validation (best-effort SSRF guard against redirect-to-private-IP)
- Redirect target HTTPS enforcement (blocks HTTP downgrade via `Location`)
- Response body cancelled on all early-exit paths (redirect hops, content-type reject, byte cap)
- Content-type allowlist (html/markdown/plain)
- 500KB body stream cap with AbortSignal timeout
- Single `clearTimeout` in `finally` covers headers + body read phase

Known limitations documented in JSDoc (deferred to Phase 3 — ipaddr.js + undici dispatcher):
- DNS rebinding TOCTOU
- IPv6 ULA/link-local, IPv4-mapped, CGNAT regex gaps
- IPv6 hostname substitution (IP pinning not implemented)

**Test coverage:** 10 cases — valid fetch, HTTP rejection, 127.0.0.1, 10.x.x.x private IP, redirect chain > 3, bad content-type, body > 500KB, timeout, redirect-to-HTTP downgrade, redirect-to-private-IP.

**Swarm:** Tier 1 (Claude) + Tier 2 (Codex) — 6 review rounds, all findings resolved.

Part of #9.