### PR TITLE
feat(narrator): rate limiting — hourly + daily cap (#13)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,5 +24,7 @@ export const config = {
     maxSourceWords: Number(optional('NARRATOR_MAX_SOURCE_WORDS', '8000')),
     storiesDir: optional('NARRATOR_STORIES_DIR', '/home/claude/claudes-world/.world/stories'),
     tmpDir: optional('NARRATOR_TMP_DIR', '/tmp'),
+    maxJobsPerHour: Number(optional('NARRATOR_MAX_JOBS_PER_HOUR', '10')),
+    maxDailyTtsUsd: Number(optional('NARRATOR_MAX_DAILY_TTS_USD', '5.00')),
   },
 };

--- a/src/delivery/narrator.ts
+++ b/src/delivery/narrator.ts
@@ -6,9 +6,11 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 import { config } from '../config.js';
 import { buildSubprocessEnv } from '../lib/claude-subprocess.js';
+import { recordSpend } from '../lib/rate-limit.js';
 
 export interface DeliveryOptions {
   jobId: string;
+  userId: number;
   narrative: string;
   stopReason: string;
   ctx: Context;
@@ -16,7 +18,7 @@ export interface DeliveryOptions {
 }
 
 export async function deliverNarration(opts: DeliveryOptions): Promise<void> {
-  const { jobId, narrative, stopReason, ctx, db } = opts;
+  const { jobId, userId, narrative, stopReason, ctx, db } = opts;
 
   // 1. Build story file path
   const now = new Date();
@@ -148,6 +150,13 @@ export async function deliverNarration(opts: DeliveryOptions): Promise<void> {
     `).run(Date.now(), mdPath, ttsChars, ttsUsd, jobId);
     if ((result as { changes: number }).changes === 0) {
       console.warn(`narrator: job ${jobId} status was not active at completion — skipping completed update`);
+    } else if (ttsUsd > 0) {
+      // Record spend for daily cap enforcement — only on successful job completion
+      try {
+        recordSpend(db, userId, ttsUsd);
+      } catch (spendErr) {
+        console.error('narrator: recordSpend failed (non-fatal):', spendErr);
+      }
     }
   } catch (dbErr) {
     console.error('narrator: DB update failed after delivery:', dbErr);

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -8,6 +8,7 @@ import { config } from '../config.js';
 import { getTracer, withSpan } from '../lib/otel.js';
 import { deliverNarration } from '../delivery/narrator.js';
 import { buildSubprocessEnv } from '../lib/claude-subprocess.js';
+import { checkAndRecordRate } from '../lib/rate-limit.js';
 
 const SYSTEM_PROMPT_PARTS = [
   '/home/claude/claudes-world/agents/narrator/.claude/output-styles/narrator.md',
@@ -39,6 +40,15 @@ export function createNarratorHandler(db: Database.Database) {
 
     // 1. Filter — silently reject if not in allowlist
     if (!config.narrator.allowedUserIds.has(userId)) return;
+
+    // Rate limit check (after allowlist, before Claude)
+    const rateResult = checkAndRecordRate(db, userId, 'narrator');
+    if (rateResult !== 'ok') {
+      await ctx.reply(rateResult === 'exceeded-hourly'
+        ? 'Rate limit: max 10 narrations per hour. Try again later.'
+        : `Daily cost cap reached ($${config.narrator.maxDailyTtsUsd.toFixed(2)}). Resets at midnight ET.`);
+      return;
+    }
 
     const sourceText = ctx.message?.text;
     if (!sourceText) return;

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -41,15 +41,6 @@ export function createNarratorHandler(db: Database.Database) {
     // 1. Filter — silently reject if not in allowlist
     if (!config.narrator.allowedUserIds.has(userId)) return;
 
-    // Rate limit check (after allowlist, before Claude)
-    const rateResult = checkAndRecordRate(db, userId, 'narrator');
-    if (rateResult !== 'ok') {
-      await ctx.reply(rateResult === 'exceeded-hourly'
-        ? 'Rate limit: max 10 narrations per hour. Try again later.'
-        : `Daily cost cap reached ($${config.narrator.maxDailyTtsUsd.toFixed(2)}). Resets at midnight ET.`);
-      return;
-    }
-
     const sourceText = ctx.message?.text;
     if (!sourceText) return;
 
@@ -57,6 +48,15 @@ export function createNarratorHandler(db: Database.Database) {
     const wordCount = sourceText.split(/\s+/).filter(Boolean).length;
     if (wordCount > config.narrator.maxSourceWords) {
       console.log(`narrator: rejected oversized input (${wordCount} words) from user ${userId}`);
+      return;
+    }
+
+    // Rate limit check (after text + word-count validation, before Claude — only valid jobs consume quota)
+    const rateResult = checkAndRecordRate(db, userId, 'narrator');
+    if (rateResult !== 'ok') {
+      await ctx.reply(rateResult === 'exceeded-hourly'
+        ? 'Rate limit: max 10 narrations per hour. Try again later.'
+        : `Daily cost cap reached ($${config.narrator.maxDailyTtsUsd.toFixed(2)}). Resets on a rolling 24-hour window.`);
       return;
     }
 
@@ -135,6 +135,7 @@ export function createNarratorHandler(db: Database.Database) {
       // 7. Deliver (writes story file, runs md-speak, sends audio, updates output_path/tts_chars/tts_usd)
       await deliverNarration({
         jobId,
+        userId,
         narrative,
         stopReason,
         ctx,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,52 @@
+import Database from 'better-sqlite3';
+import { config } from '../config.js';
+
+export function checkAndRecordRate(db: Database.Database, userId: number, handler: string): "ok" | "exceeded-hourly" | "exceeded-daily" {
+  const now = Date.now();
+  const oneHourAgo = now - 60 * 60 * 1000;
+  const oneDayAgo = now - 24 * 60 * 60 * 1000;
+
+  // Prune stale hourly rows (older than 1h) on every call
+  db.prepare(`DELETE FROM rate_limits_hourly WHERE timestamp < ?`).run(oneHourAgo);
+
+  // Check hourly count for this user+handler
+  const hourlyCount = (db.prepare(`
+    SELECT COUNT(*) as count FROM rate_limits_hourly
+    WHERE user_id = ? AND handler = ? AND timestamp >= ?
+  `).get(userId, handler, oneHourAgo) as { count: number }).count;
+
+  if (hourlyCount >= config.narrator.maxJobsPerHour) {
+    return "exceeded-hourly";
+  }
+
+  // Prune stale daily spend rows (older than 24h)
+  db.prepare(`DELETE FROM rate_limits_daily_spend WHERE timestamp < ?`).run(oneDayAgo);
+
+  // Check daily spend
+  const spendRow = db.prepare(`
+    SELECT COALESCE(SUM(tts_usd), 0) as total FROM rate_limits_daily_spend
+    WHERE user_id = ? AND timestamp >= ?
+  `).get(userId, oneDayAgo) as { total: number };
+
+  if (spendRow.total >= config.narrator.maxDailyTtsUsd) {
+    return "exceeded-daily";
+  }
+
+  // Record this job in hourly table
+  db.prepare(`INSERT INTO rate_limits_hourly (user_id, handler, timestamp) VALUES (?, ?, ?)`).run(userId, handler, now);
+
+  return "ok";
+}
+
+export function recordSpend(db: Database.Database, userId: number, ttsUsd: number): void {
+  db.prepare(`INSERT INTO rate_limits_daily_spend (user_id, timestamp, tts_usd) VALUES (?, ?, ?)`).run(userId, Date.now(), ttsUsd);
+}
+
+export function dailySpend(db: Database.Database, userId: number): number {
+  const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
+  const row = db.prepare(`
+    SELECT COALESCE(SUM(tts_usd), 0) as total FROM rate_limits_daily_spend
+    WHERE user_id = ? AND timestamp >= ?
+  `).get(userId, oneDayAgo) as { total: number };
+  return row.total;
+}

--- a/test/lib/rate-limit.test.ts
+++ b/test/lib/rate-limit.test.ts
@@ -1,0 +1,106 @@
+import Database from 'better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { checkAndRecordRate, dailySpend, recordSpend } from '../../src/lib/rate-limit.js';
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS rate_limits_hourly (
+      id        INTEGER PRIMARY KEY,
+      user_id   INTEGER NOT NULL,
+      handler   TEXT NOT NULL,
+      timestamp INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_rl_hourly_user_ts ON rate_limits_hourly(user_id, timestamp);
+
+    CREATE TABLE IF NOT EXISTS rate_limits_daily_spend (
+      id        INTEGER PRIMARY KEY,
+      user_id   INTEGER NOT NULL,
+      timestamp INTEGER NOT NULL,
+      tts_usd   REAL NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_rl_daily_user_ts ON rate_limits_daily_spend(user_id, timestamp);
+  `);
+  return db;
+}
+
+describe('checkAndRecordRate', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('1. 10 consecutive calls return "ok"', () => {
+    for (let i = 0; i < 10; i++) {
+      expect(checkAndRecordRate(db, 1, 'narrator')).toBe('ok');
+    }
+  });
+
+  it('2. 11th call returns "exceeded-hourly"', () => {
+    for (let i = 0; i < 10; i++) {
+      checkAndRecordRate(db, 1, 'narrator');
+    }
+    expect(checkAndRecordRate(db, 1, 'narrator')).toBe('exceeded-hourly');
+  });
+
+  it('3. pruning: stale hourly rows (2h old) are pruned on next call', () => {
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    // Insert 15 stale rows directly
+    const insert = db.prepare(`INSERT INTO rate_limits_hourly (user_id, handler, timestamp) VALUES (?, ?, ?)`);
+    for (let i = 0; i < 15; i++) {
+      insert.run(1, 'narrator', twoHoursAgo);
+    }
+    // Call checkAndRecordRate — pruning fires, stale rows deleted, count starts at 0, returns "ok"
+    expect(checkAndRecordRate(db, 1, 'narrator')).toBe('ok');
+    // Verify stale rows are gone — only the 1 we just recorded remains
+    const count = (db.prepare(`SELECT COUNT(*) as count FROM rate_limits_hourly WHERE user_id = 1`).get() as { count: number }).count;
+    expect(count).toBe(1);
+  });
+
+  it('4. daily spend $4.50 → ok; then add $0.60 → exceeded-daily on next check', () => {
+    // Seed daily spend: $4.50 (below $5.00 cap)
+    recordSpend(db, 1, 4.50);
+    // First check — passes hourly and daily → "ok" (also records hourly entry)
+    expect(checkAndRecordRate(db, 1, 'narrator')).toBe('ok');
+
+    // Now push total over cap
+    recordSpend(db, 1, 0.60);
+
+    // Next check — daily spend $5.10 >= $5.00 → "exceeded-daily"
+    expect(checkAndRecordRate(db, 1, 'narrator')).toBe('exceeded-daily');
+  });
+
+  it('5. different user_id isolates limits — user A at limit does not affect user B', () => {
+    // User A hits hourly limit
+    for (let i = 0; i < 10; i++) {
+      checkAndRecordRate(db, 1, 'narrator');
+    }
+    expect(checkAndRecordRate(db, 1, 'narrator')).toBe('exceeded-hourly');
+
+    // User B is unaffected
+    expect(checkAndRecordRate(db, 2, 'narrator')).toBe('ok');
+  });
+});
+
+describe('dailySpend', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('6. returns correct sum of spend within last 24h', () => {
+    recordSpend(db, 1, 1.25);
+    recordSpend(db, 1, 2.50);
+    // Old spend outside 24h window — should not be counted
+    const old = Date.now() - 25 * 60 * 60 * 1000;
+    db.prepare(`INSERT INTO rate_limits_daily_spend (user_id, timestamp, tts_usd) VALUES (?, ?, ?)`).run(1, old, 10.00);
+
+    expect(dailySpend(db, 1)).toBeCloseTo(3.75);
+  });
+
+  it('returns 0 when no spend recorded', () => {
+    expect(dailySpend(db, 999)).toBe(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
+    env: {
+      TELEGRAM_NARRATOR_BOT_TOKEN: 'test-token',
+    },
   },
 });


### PR DESCRIPTION
Closes #13

Implements rate limiting per Phase 2 spec.

- `checkAndRecordRate` — hourly job count + daily spend check with auto-pruning
- `recordSpend` — records TTS cost for daily cap tracking (called in `deliverNarration` on successful TTS)
- `dailySpend` — query current 24h spend for a user
- Config: `NARRATOR_MAX_JOBS_PER_HOUR` (default 10), `NARRATOR_MAX_DAILY_TTS_USD` (default 5.00)
- Narrator handler integration: rate check after text + word-count validation, before Claude invocation
- Fixes from Codex review: recordSpend was not wired (daily cap always 0), rate check ran before text validation (non-text messages burned hourly slots)

Part of #9.