### PR TITLE
feat(narrator): OAuth retry-once wrapper (#14)

### DIFF
--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -1,13 +1,12 @@
 import { Context } from 'grammy';
 import Database from 'better-sqlite3';
-import { execa } from 'execa';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { config } from '../config.js';
 import { getTracer, withSpan } from '../lib/otel.js';
 import { deliverNarration } from '../delivery/narrator.js';
-import { buildSubprocessEnv } from '../lib/claude-subprocess.js';
+import { buildSubprocessEnv, spawnClaudeWithRetry, ClaudeEnvelope } from '../lib/claude-subprocess.js';
 import { checkAndRecordRate } from '../lib/rate-limit.js';
 
 const SYSTEM_PROMPT_PARTS = [
@@ -18,18 +17,6 @@ const SYSTEM_PROMPT_PARTS = [
 const USER_PROMPT = `Rewrite the source provided via stdin as a serious origin-story narrative suitable for text-to-speech playback.
 Target length: medium (approximately 600-900 words of output).
 Respond ONLY with the narrative prose — do not write files, do not include preamble, do not add commentary at the end.`;
-
-interface ClaudeEnvelope {
-  type: string;
-  subtype: string;
-  is_error: boolean;
-  result: string;
-  stop_reason: string;
-  usage?: {
-    input_tokens: number;
-    output_tokens: number;
-  };
-}
 
 const tracer = getTracer('narrator');
 
@@ -172,57 +159,18 @@ interface SpawnResult {
 }
 
 async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
-  let retried = false;
-
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const proc = await execa(opts.runScript, [
-        '-p', USER_PROMPT,
-        '--output-format', 'json',
-        '--append-system-prompt-file', opts.sysFile,
-        '--model', opts.model,
-        '--allowedTools', '',  // zero-tool allowlist — narrator rewrite needs no tools; empty allowlist > denylist
-      ], {
-        input: opts.sourceText,
-        extendEnv: false,
-        // OAuth-only per ADR 0013 — ANTHROPIC_API_KEY intentionally excluded.
-        // run.sh sets CLAUDE_CONFIG_DIR pointing to .credentials.json symlink.
-        // buildSubprocessEnv allowlist: PATH, HOME, TZ only — TELEGRAM_*/NARRATOR_*/ANTHROPIC_* never forwarded.
-        env: buildSubprocessEnv(process.env, {
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '12000',
-        }),
-        timeout: opts.timeout,
-        cleanup: true,
-        killSignal: 'SIGKILL',
-      });
-
-      let envelope: ClaudeEnvelope;
-      try {
-        const parsed = JSON.parse(proc.stdout) as Record<string, unknown>;
-        // Runtime shape check — ensure critical fields are present
-        if (typeof parsed['is_error'] !== 'boolean' || typeof parsed['result'] !== 'string') {
-          throw new Error(`Malformed Claude envelope — missing is_error or result. stdout: ${proc.stdout.slice(0, 200)}`);
-        }
-        envelope = parsed as unknown as ClaudeEnvelope;
-      } catch (parseErr) {
-        throw new Error(`Failed to parse Claude output: ${String(parseErr)}. stdout: ${proc.stdout.slice(0, 200)}`);
-      }
-      return { envelope, retried };
-
-    } catch (err: unknown) {
-      const msg = String(err);
-      const isAuthError = msg.includes('401') || msg.includes('authentication') || msg.includes('OAuth');
-
-      if (attempt === 0 && isAuthError) {
-        retried = true;
-        console.warn('narrator: OAuth error on attempt 1, retrying once...');
-        await new Promise(r => setTimeout(r, 2000));
-        continue;
-      }
-
-      throw err;
-    }
-  }
-
-  throw new Error('narrator: exhausted retries');
+  const args = [
+    '-p', USER_PROMPT,
+    '--output-format', 'json',
+    '--append-system-prompt-file', opts.sysFile,
+    '--model', opts.model,
+    '--allowedTools', '',  // zero-tool allowlist — narrator rewrite needs no tools; empty allowlist > denylist
+  ];
+  // OAuth-only per ADR 0013 — ANTHROPIC_API_KEY intentionally excluded.
+  // run.sh sets CLAUDE_CONFIG_DIR pointing to .credentials.json symlink.
+  // buildSubprocessEnv allowlist: PATH, HOME, TZ only — TELEGRAM_*/NARRATOR_*/ANTHROPIC_* never forwarded.
+  const env = buildSubprocessEnv(process.env, {
+    CLAUDE_CODE_MAX_OUTPUT_TOKENS: '12000',
+  });
+  return spawnClaudeWithRetry(opts.runScript, args, opts.sourceText, env, opts.timeout);
 }

--- a/src/lib/claude-subprocess.ts
+++ b/src/lib/claude-subprocess.ts
@@ -1,11 +1,13 @@
 /**
- * Subprocess environment helpers.
+ * Subprocess environment helpers and Claude subprocess runner.
  *
  * Guarantees that sensitive credentials (TELEGRAM_*, NARRATOR_*, ANTHROPIC_*)
  * never leak into child process environments. Only an explicit allowlist of
  * variables is forwarded from `base`; callers pass any additional needed vars
  * via `extra`, which is also guarded against forbidden prefixes.
  */
+
+import { execa } from 'execa';
 
 const ALLOWED_KEYS = ['PATH', 'HOME', 'TZ'] as const;
 
@@ -48,4 +50,122 @@ export function buildSubprocessEnv(
 
   Object.assign(result, extra);
   return result;
+}
+
+export interface ClaudeEnvelope {
+  type: string;
+  subtype: string;
+  is_error: boolean;
+  result: string;
+  stop_reason: string;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+/**
+ * Detect whether a Claude error envelope or thrown-error message indicates
+ * an OAuth/auth failure worth retrying.
+ *
+ * Observed auth-error shapes (from live experiment 2026-04-15):
+ *   - Process exits with code 1 (thrown by execa)
+ *   - stdout is a valid JSON envelope with is_error: true
+ *   - envelope.result: "Not logged in · Please run /login"
+ *   - envelope.subtype: "success" (misleading — is_error flag is the real signal)
+ *   - No 401 HTTP codes in the output — the check is on "login"/"logged in" text
+ */
+function isAuthError(envelope: ClaudeEnvelope | null, thrownMsg: string): boolean {
+  // Check thrown exception message
+  if (/401|authentication|OAuth|credentials|unauthorized|not logged in|please run.*login/i.test(thrownMsg)) return true;
+  // Check is_error envelope result text
+  if (envelope?.is_error) {
+    const result = envelope.result ?? '';
+    if (/401|authentication|OAuth|credentials|unauthorized|not logged in|please run.*login/i.test(result)) return true;
+  }
+  return false;
+}
+
+/**
+ * Spawn a Claude subprocess and retry once on auth errors.
+ *
+ * Handles both thrown exceptions (e.g. non-zero exit) and is_error envelopes.
+ * On auth errors the process may exit non-zero but still write valid JSON to
+ * stdout — we parse stdout from the caught ExecaError in that case.
+ *
+ * @param runScript - Path to the agent run script (e.g. narrator/run.sh)
+ * @param args      - CLI args to pass to the script
+ * @param input     - stdin content
+ * @param env       - subprocess env (use buildSubprocessEnv)
+ * @param timeout   - timeout in ms
+ */
+export async function spawnClaudeWithRetry(
+  runScript: string,
+  args: string[],
+  input: string,
+  env: NodeJS.ProcessEnv,
+  timeout: number,
+): Promise<{ envelope: ClaudeEnvelope; retried: boolean }> {
+  let retried = false;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let envelope: ClaudeEnvelope | null = null;
+    let thrownMsg = '';
+
+    try {
+      const proc = await execa(runScript, args, {
+        input,
+        extendEnv: false,
+        env,
+        timeout,
+        cleanup: true,
+        killSignal: 'SIGKILL',
+      });
+
+      try {
+        const parsed = JSON.parse(proc.stdout) as Record<string, unknown>;
+        if (typeof parsed['is_error'] !== 'boolean' || typeof parsed['result'] !== 'string') {
+          throw new Error(`Malformed Claude envelope — missing is_error or result. stdout: ${proc.stdout.slice(0, 200)}`);
+        }
+        envelope = parsed as unknown as ClaudeEnvelope;
+      } catch (parseErr) {
+        throw new Error(`Failed to parse Claude output: ${String(parseErr)}. stdout: ${proc.stdout.slice(0, 200)}`);
+      }
+
+      // If is_error envelope, check if it's auth-related
+      if (envelope.is_error && attempt === 0 && isAuthError(envelope, '')) {
+        retried = true;
+        console.warn('narrator: OAuth error in envelope on attempt 1, retrying once...');
+        await new Promise(r => setTimeout(r, 2000));
+        continue;
+      }
+
+      return { envelope, retried };
+
+    } catch (err: unknown) {
+      thrownMsg = String(err);
+
+      // Auth failures (e.g. "Not logged in") cause non-zero exit but write valid JSON to stdout.
+      // Try to parse stdout from the ExecaError before deciding whether to retry.
+      const errStdout = (err as Record<string, unknown>)['stdout'];
+      if (typeof errStdout === 'string' && errStdout.trim()) {
+        try {
+          const parsed = JSON.parse(errStdout) as Record<string, unknown>;
+          if (typeof parsed['is_error'] === 'boolean' && typeof parsed['result'] === 'string') {
+            envelope = parsed as unknown as ClaudeEnvelope;
+          }
+        } catch { /* not JSON, ignore */ }
+      }
+
+      if (attempt === 0 && isAuthError(envelope, thrownMsg)) {
+        retried = true;
+        console.warn('narrator: OAuth error on attempt 1, retrying once...');
+        await new Promise(r => setTimeout(r, 2000));
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw new Error('spawnClaudeWithRetry: unreachable — loop exhausted');
 }

--- a/test/lib/claude-subprocess.test.ts
+++ b/test/lib/claude-subprocess.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { buildSubprocessEnv } from '../../src/lib/claude-subprocess.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildSubprocessEnv, spawnClaudeWithRetry } from '../../src/lib/claude-subprocess.js';
 
 describe('buildSubprocessEnv', () => {
   it('includes PATH, HOME, TZ when present in base', () => {
@@ -71,5 +71,130 @@ describe('buildSubprocessEnv', () => {
     expect(() =>
       buildSubprocessEnv({}, { NARRATOR_ALLOWED_USER_IDS: '123' }),
     ).toThrow(/forbidden key/);
+  });
+});
+
+// ─── spawnClaudeWithRetry ────────────────────────────────────────────────────
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+import { execa } from 'execa';
+const mockedExeca = vi.mocked(execa);
+
+/** Build a minimal valid ClaudeEnvelope JSON string. */
+function makeEnvelopeStdout(is_error: boolean, result: string): string {
+  return JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    is_error,
+    result,
+    stop_reason: 'stop_sequence',
+  });
+}
+
+/** Build a fake ExecaError (non-zero exit) with stdout set. */
+function makeExecaError(stdout: string, exitCode = 1): Error {
+  const err = new Error(`Command failed with exit code ${exitCode}: /run.sh`) as Error & {
+    stdout: string;
+    exitCode: number;
+  };
+  err.stdout = stdout;
+  err.exitCode = exitCode;
+  return err;
+}
+
+describe('spawnClaudeWithRetry', () => {
+  const RUN = '/fake/run.sh';
+  const ARGS = ['-p', 'hi'];
+  const ENV = { PATH: '/usr/bin', HOME: '/home/test' };
+  const TIMEOUT = 5000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Speed up retry delay in tests
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clean success — retried: false', async () => {
+    const stdout = makeEnvelopeStdout(false, 'nice narrative');
+    mockedExeca.mockResolvedValueOnce({ stdout, stderr: '', exitCode: 0 } as ReturnType<typeof execa>);
+
+    const promise = spawnClaudeWithRetry(RUN, ARGS, 'input', ENV, TIMEOUT);
+    await vi.runAllTimersAsync();
+    const { envelope, retried } = await promise;
+
+    expect(retried).toBe(false);
+    expect(envelope.is_error).toBe(false);
+    expect(envelope.result).toBe('nice narrative');
+  });
+
+  it('auth error via thrown exception on attempt 1 — retried: true, succeeds on attempt 2', async () => {
+    const authErr = makeExecaError(makeEnvelopeStdout(true, 'Not logged in · Please run /login'));
+    const successStdout = makeEnvelopeStdout(false, 'recovered narrative');
+
+    mockedExeca
+      .mockRejectedValueOnce(authErr)
+      .mockResolvedValueOnce({ stdout: successStdout, stderr: '', exitCode: 0 } as ReturnType<typeof execa>);
+
+    const promise = spawnClaudeWithRetry(RUN, ARGS, 'input', ENV, TIMEOUT);
+    await vi.runAllTimersAsync();
+    const { envelope, retried } = await promise;
+
+    expect(retried).toBe(true);
+    expect(envelope.is_error).toBe(false);
+    expect(envelope.result).toBe('recovered narrative');
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
+  });
+
+  it('auth error via is_error envelope on attempt 1 — retried: true, succeeds on attempt 2', async () => {
+    const authStdout = makeEnvelopeStdout(true, 'Not logged in · Please run /login');
+    const successStdout = makeEnvelopeStdout(false, 'recovered narrative');
+
+    mockedExeca
+      .mockResolvedValueOnce({ stdout: authStdout, stderr: '', exitCode: 0 } as ReturnType<typeof execa>)
+      .mockResolvedValueOnce({ stdout: successStdout, stderr: '', exitCode: 0 } as ReturnType<typeof execa>);
+
+    const promise = spawnClaudeWithRetry(RUN, ARGS, 'input', ENV, TIMEOUT);
+    await vi.runAllTimersAsync();
+    const { envelope, retried } = await promise;
+
+    expect(retried).toBe(true);
+    expect(envelope.is_error).toBe(false);
+    expect(envelope.result).toBe('recovered narrative');
+  });
+
+  it('auth error on both attempts — throws', async () => {
+    const authErr = makeExecaError(makeEnvelopeStdout(true, 'Not logged in · Please run /login'));
+
+    mockedExeca
+      .mockRejectedValueOnce(authErr)
+      .mockRejectedValueOnce(authErr);
+
+    // Attach rejects handler immediately to prevent unhandled rejection warnings
+    const resultPromise = expect(
+      spawnClaudeWithRetry(RUN, ARGS, 'input', ENV, TIMEOUT),
+    ).rejects.toThrow();
+    await vi.runAllTimersAsync();
+    await resultPromise;
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
+  });
+
+  it('non-auth error — throws immediately without retry', async () => {
+    const nonAuthErr = new Error('Something else went wrong entirely');
+    mockedExeca.mockRejectedValueOnce(nonAuthErr);
+
+    // Attach rejects handler immediately to prevent unhandled rejection warnings
+    const resultPromise = expect(
+      spawnClaudeWithRetry(RUN, ARGS, 'input', ENV, TIMEOUT),
+    ).rejects.toThrow('Something else went wrong entirely');
+    await vi.runAllTimersAsync();
+    await resultPromise;
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #14

Extracts `spawnClaudeWithRetry` from narrator handler into `src/lib/claude-subprocess.ts`. Retries once on OAuth/auth errors — both thrown exceptions and is_error envelopes.

Auth error detection: regex on message/result for `401`, `authentication`, `OAuth`, `credentials`, `unauthorized`, `not logged in`, `please run.*login`.

**Observed auth-error shape from live experiment 2026-04-15:**
- Process exits non-zero (exit code 1), execa throws
- stdout is valid JSON envelope: `is_error: true`, `result: "Not logged in · Please run /login"`, `subtype: "success"` (misleading — `is_error` flag is the real signal)
- No HTTP 401 codes in the output — detection is on the "login" text in `result`
- The implementation parses stdout from the caught ExecaError so the envelope is available for auth-check before deciding to retry

**Changes:**
- `src/lib/claude-subprocess.ts` — new `ClaudeEnvelope` interface, `isAuthError()` helper, `spawnClaudeWithRetry()` exported function + `import { execa }` added
- `src/handlers/narrator.ts` — removed local `ClaudeEnvelope` interface + inline retry loop, `spawnNarrator` now delegates to `spawnClaudeWithRetry`; removed `execa` import (moved to claude-subprocess)
- `test/lib/claude-subprocess.test.ts` — 5 new tests for `spawnClaudeWithRetry` (success, thrown-auth-retry, envelope-auth-retry, both-fail, non-auth-no-retry)

**Test results:** 39 tests passing (0 failures, 0 errors)

**Local swarm:** Tier 1 (Claude) CLEAN · Tier 2 (Codex) CLEAN

Part of #9.