### PR TITLE
feat(narrator): inline length keyboard + callback handler (#34)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,5 +26,6 @@ export const config = {
     tmpDir: optional('NARRATOR_TMP_DIR', '/tmp'),
     maxJobsPerHour: Number(optional('NARRATOR_MAX_JOBS_PER_HOUR', '10')),
     maxDailyTtsUsd: Number(optional('NARRATOR_MAX_DAILY_TTS_USD', '5.00')),
+    lengthTimeoutMs: Number(optional('NARRATOR_LENGTH_TIMEOUT', '20')) * 1000,
   },
 };

--- a/src/handlers/narrator-callback.ts
+++ b/src/handlers/narrator-callback.ts
@@ -1,5 +1,6 @@
 import { Context } from 'grammy';
 import Database from 'better-sqlite3';
+import fs from 'node:fs/promises';
 
 interface PendingChoice {
   job_id: string;
@@ -40,13 +41,13 @@ export function createLengthCallbackHandler(
       return;
     }
 
-    // Verify nonce — look up the pending choice
+    // Atomically consume nonce — any concurrent path gets nothing (TOCTOU fix)
     const pending = db.prepare(
-      `SELECT * FROM pending_length_choices WHERE job_id = ?`
+      `DELETE FROM pending_length_choices WHERE job_id = ? RETURNING *`
     ).get(jobId) as PendingChoice | undefined;
 
     if (!pending) {
-      // Stale keyboard — already handled or timed out
+      // Already consumed (race) or never existed
       try {
         await ctx.editMessageText('⏱ Selection expired — already processed or timed out.');
       } catch { /* message may have been deleted */ }
@@ -54,20 +55,41 @@ export function createLengthCallbackHandler(
       return;
     }
 
-    // Sweep other pending keyboards for this chat_id (stale keyboard cleanup)
+    // Validate chat_id matches (prevents cross-chat replay)
+    if (ctx.chat?.id !== pending.chat_id) {
+      console.warn(`narrator: callback chat_id mismatch — got ${ctx.chat?.id}, expected ${pending.chat_id}`);
+      try { await ctx.answerCallbackQuery({ text: 'Invalid selection.' }); } catch { /* non-fatal */ }
+      return;
+    }
+
+    // Check expires_at (belt-and-suspenders; row may have been kept by startup rebuild)
+    if (Date.now() > pending.expires_at) {
+      if (pending.keyboard_msg_id) {
+        try { await ctx.editMessageText('⏱ Selection expired.'); } catch { /* swallow */ }
+      }
+      db.prepare(`UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ? AND status = 'active'`)
+        .run(Date.now(), 'length selection expired', pending.job_id);
+      try { await fs.unlink(pending.source_tmpfile); } catch { /* already gone */ }
+      try { await ctx.answerCallbackQuery({ text: 'Selection expired.' }); } catch { /* non-fatal */ }
+      return;
+    }
+
+    // Sweep other pending keyboards for this chat_id — clean up jobs + temp files (stale keyboard fix)
     const others = db.prepare(
-      `SELECT keyboard_msg_id FROM pending_length_choices WHERE chat_id = ? AND job_id != ?`
-    ).all(pending.chat_id, jobId) as { keyboard_msg_id: number }[];
+      `DELETE FROM pending_length_choices WHERE chat_id = ? AND job_id != ? RETURNING job_id, keyboard_msg_id, source_tmpfile`
+    ).all(pending.chat_id, jobId) as { job_id: string; keyboard_msg_id: number; source_tmpfile: string }[];
 
     for (const other of others) {
+      // Disable keyboard UI
       try {
         await ctx.api.editMessageReplyMarkup(pending.chat_id, other.keyboard_msg_id, undefined);
       } catch { /* message may have been deleted or already removed */ }
+      // Mark job cancelled (was never started)
+      db.prepare(`UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ? AND status = 'active'`)
+        .run(Date.now(), 'superseded by newer keyboard selection', other.job_id);
+      // Clean up temp file
+      try { await fs.unlink(other.source_tmpfile); } catch { /* already gone */ }
     }
-    db.prepare(`DELETE FROM pending_length_choices WHERE chat_id = ? AND job_id != ?`).run(pending.chat_id, jobId);
-
-    // Remove this pending choice from DB (consume the nonce)
-    db.prepare(`DELETE FROM pending_length_choices WHERE job_id = ?`).run(jobId);
 
     // Edit keyboard message to show selection
     const labelMap = { short: 'short (~2min)', medium: 'medium (3-7min)', full: 'full length' };
@@ -75,7 +97,12 @@ export function createLengthCallbackHandler(
       await ctx.editMessageText(`Rewriting in ${labelMap[length]} mode…`);
     } catch { /* swallow */ }
 
-    await ctx.answerCallbackQuery();
+    // Wrap answerCallbackQuery so a throw doesn't prevent onLengthChosen
+    try {
+      await ctx.answerCallbackQuery();
+    } catch (err) {
+      console.warn('narrator: answerCallbackQuery failed (non-fatal):', err);
+    }
 
     // Invoke the continuation (will spawn Claude rewrite)
     await onLengthChosen(jobId, length, ctx);

--- a/src/handlers/narrator-callback.ts
+++ b/src/handlers/narrator-callback.ts
@@ -1,0 +1,83 @@
+import { Context } from 'grammy';
+import Database from 'better-sqlite3';
+
+interface PendingChoice {
+  job_id: string;
+  chat_id: number;
+  keyboard_msg_id: number;
+  source_tmpfile: string;
+  tone_prefix: string | null;
+  shape_prefix: string | null;
+  expires_at: number;
+}
+
+/**
+ * Handle inline keyboard callback for length selection.
+ * callback_data format: "length:<jobId>:<short|medium|full>"
+ */
+export function createLengthCallbackHandler(
+  db: Database.Database,
+  onLengthChosen: (jobId: string, length: 'short' | 'medium' | 'full', ctx: Context) => Promise<void>
+) {
+  return async function lengthCallbackHandler(ctx: Context): Promise<void> {
+    const data = ctx.callbackQuery?.data;
+    if (!data?.startsWith('length:')) {
+      await ctx.answerCallbackQuery();
+      return;
+    }
+
+    const parts = data.split(':');
+    if (parts.length !== 3) {
+      await ctx.answerCallbackQuery({ text: 'Invalid selection.' });
+      return;
+    }
+
+    const [, jobId, lengthStr] = parts;
+    const length = lengthStr as 'short' | 'medium' | 'full';
+
+    if (!['short', 'medium', 'full'].includes(length)) {
+      await ctx.answerCallbackQuery({ text: 'Invalid length.' });
+      return;
+    }
+
+    // Verify nonce — look up the pending choice
+    const pending = db.prepare(
+      `SELECT * FROM pending_length_choices WHERE job_id = ?`
+    ).get(jobId) as PendingChoice | undefined;
+
+    if (!pending) {
+      // Stale keyboard — already handled or timed out
+      try {
+        await ctx.editMessageText('⏱ Selection expired — already processed or timed out.');
+      } catch { /* message may have been deleted */ }
+      await ctx.answerCallbackQuery({ text: 'This selection has expired.' });
+      return;
+    }
+
+    // Sweep other pending keyboards for this chat_id (stale keyboard cleanup)
+    const others = db.prepare(
+      `SELECT keyboard_msg_id FROM pending_length_choices WHERE chat_id = ? AND job_id != ?`
+    ).all(pending.chat_id, jobId) as { keyboard_msg_id: number }[];
+
+    for (const other of others) {
+      try {
+        await ctx.api.editMessageReplyMarkup(pending.chat_id, other.keyboard_msg_id, undefined);
+      } catch { /* message may have been deleted or already removed */ }
+    }
+    db.prepare(`DELETE FROM pending_length_choices WHERE chat_id = ? AND job_id != ?`).run(pending.chat_id, jobId);
+
+    // Remove this pending choice from DB (consume the nonce)
+    db.prepare(`DELETE FROM pending_length_choices WHERE job_id = ?`).run(jobId);
+
+    // Edit keyboard message to show selection
+    const labelMap = { short: 'short (~2min)', medium: 'medium (3-7min)', full: 'full length' };
+    try {
+      await ctx.editMessageText(`Rewriting in ${labelMap[length]} mode…`);
+    } catch { /* swallow */ }
+
+    await ctx.answerCallbackQuery();
+
+    // Invoke the continuation (will spawn Claude rewrite)
+    await onLengthChosen(jobId, length, ctx);
+  };
+}

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -100,14 +100,13 @@ export function createNarratorHandler(db: Database.Database) {
       console.warn('narrator: ack send failed (best-effort):', ackErr);
     }
 
-    // 5. Record pending length choice
+    // 5. Record pending length choice — always insert so timeout can fire even if ack failed.
+    // keyboard_msg_id = 0 signals ack was not sent (no message to edit on timeout).
     const expiresAt = Date.now() + config.narrator.lengthTimeoutMs;
-    if (ackMessageId) {
-      db.prepare(`
-        INSERT INTO pending_length_choices (job_id, chat_id, keyboard_msg_id, source_tmpfile, tone_prefix, shape_prefix, expires_at)
-        VALUES (?, ?, ?, ?, NULL, NULL, ?)
-      `).run(jobId, chatId, ackMessageId, sourceTmpFile, expiresAt);
-    }
+    db.prepare(`
+      INSERT INTO pending_length_choices (job_id, chat_id, keyboard_msg_id, source_tmpfile, tone_prefix, shape_prefix, expires_at)
+      VALUES (?, ?, ?, ?, NULL, NULL, ?)
+    `).run(jobId, chatId, ackMessageId ?? 0, sourceTmpFile, expiresAt);
 
     // 6. Default timeout — use medium if user doesn't tap within lengthTimeoutMs
     const timeoutHandle = setTimeout(async () => {

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -79,50 +79,61 @@ export function createNarratorHandler(db: Database.Database) {
       VALUES (?, 'narrator', ?, ?, ?, 'active', 'text', 'serious', 'origin-story', NULL)
     `).run(jobId, chatId, userId, now);
 
-    // 3. Write source to temp file so continueNarration can read it after the callback
-    const sourceTmpFile = path.join(config.narrator.tmpDir, `narrator-src-${jobId}`);
-    await fs.writeFile(sourceTmpFile, sourceText);
-
-    // 4. Send inline keyboard as ack
-    const keyboard = new InlineKeyboard()
-      .text('Short (~2min)', `length:${jobId}:short`)
-      .text('Medium (default)', `length:${jobId}:medium`)
-      .text('Full length', `length:${jobId}:full`);
-
-    let ackMessageId: number | undefined;
+    // 3–6. Write temp file, send keyboard, record pending choice, arm timeout.
+    // If any step fails, mark job failed and clean up (MEDIUM-3: orphan cleanup on setup failure).
+    let sourceTmpFile: string | null = null;
     try {
-      const ackMsg = await ctx.reply('Got your text. Choose a length:', {
-        reply_parameters: { message_id: ctx.message!.message_id },
-        reply_markup: keyboard,
-      });
-      ackMessageId = ackMsg.message_id;
-    } catch (ackErr) {
-      console.warn('narrator: ack send failed (best-effort):', ackErr);
-    }
+      sourceTmpFile = path.join(config.narrator.tmpDir, `narrator-src-${jobId}`);
+      await fs.writeFile(sourceTmpFile, sourceText);
 
-    // 5. Record pending length choice — always insert so timeout can fire even if ack failed.
-    // keyboard_msg_id = 0 signals ack was not sent (no message to edit on timeout).
-    const expiresAt = Date.now() + config.narrator.lengthTimeoutMs;
-    db.prepare(`
-      INSERT INTO pending_length_choices (job_id, chat_id, keyboard_msg_id, source_tmpfile, tone_prefix, shape_prefix, expires_at)
-      VALUES (?, ?, ?, ?, NULL, NULL, ?)
-    `).run(jobId, chatId, ackMessageId ?? 0, sourceTmpFile, expiresAt);
+      // 4. Send inline keyboard as ack
+      const keyboard = new InlineKeyboard()
+        .text('Short (~2min)', `length:${jobId}:short`)
+        .text('Medium (default)', `length:${jobId}:medium`)
+        .text('Full length', `length:${jobId}:full`);
 
-    // 6. Default timeout — use medium if user doesn't tap within lengthTimeoutMs
-    const timeoutHandle = setTimeout(async () => {
-      const still = db.prepare(`SELECT * FROM pending_length_choices WHERE job_id = ?`).get(jobId);
-      if (!still) return; // already handled by callback
-      db.prepare(`DELETE FROM pending_length_choices WHERE job_id = ?`).run(jobId);
-      pendingTimeouts.delete(jobId);
-      if (ackMessageId) {
-        try {
-          await ctx.api.editMessageText(chatId, ackMessageId, 'Timed out — using default (medium)');
-        } catch { /* swallow */ }
+      let ackMessageId: number | undefined;
+      try {
+        const ackMsg = await ctx.reply('Got your text. Choose a length:', {
+          reply_parameters: { message_id: ctx.message!.message_id },
+          reply_markup: keyboard,
+        });
+        ackMessageId = ackMsg.message_id;
+      } catch (ackErr) {
+        console.warn('narrator: ack send failed (best-effort):', ackErr);
       }
-      await continueNarration(jobId, 'medium', ctx, db);
-    }, config.narrator.lengthTimeoutMs);
 
-    pendingTimeouts.set(jobId, timeoutHandle);
+      // 5. Record pending length choice — always insert so timeout can fire even if ack failed.
+      // keyboard_msg_id = 0 signals ack was not sent (no message to edit on timeout).
+      const expiresAt = Date.now() + config.narrator.lengthTimeoutMs;
+      db.prepare(`
+        INSERT INTO pending_length_choices (job_id, chat_id, keyboard_msg_id, source_tmpfile, tone_prefix, shape_prefix, expires_at)
+        VALUES (?, ?, ?, ?, NULL, NULL, ?)
+      `).run(jobId, chatId, ackMessageId ?? 0, sourceTmpFile, expiresAt);
+
+      // 6. Default timeout — use medium if user doesn't tap within lengthTimeoutMs
+      const timeoutHandle = setTimeout(async () => {
+        const still = db.prepare(`SELECT * FROM pending_length_choices WHERE job_id = ?`).get(jobId);
+        pendingTimeouts.delete(jobId); // Always clean up map entry (MEDIUM-1: prevent leak on early return)
+        if (!still) return; // already handled by callback
+        db.prepare(`DELETE FROM pending_length_choices WHERE job_id = ?`).run(jobId);
+        if (ackMessageId) {
+          try {
+            await ctx.api.editMessageText(chatId, ackMessageId, 'Timed out — using default (medium)');
+          } catch { /* swallow */ }
+        }
+        await continueNarration(jobId, 'medium', ctx, db);
+      }, config.narrator.lengthTimeoutMs);
+
+      pendingTimeouts.set(jobId, timeoutHandle);
+    } catch (setupErr) {
+      // Clean up orphaned job and temp file
+      if (sourceTmpFile) { try { await fs.unlink(sourceTmpFile); } catch { /* already gone */ } }
+      db.prepare(`UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ?`)
+        .run(Date.now(), String(setupErr), jobId);
+      await ctx.reply('Failed to start narration. Please try again.').catch(() => {});
+      return;
+    }
   };
 }
 

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -1,4 +1,4 @@
-import { Context } from 'grammy';
+import { Context, InlineKeyboard } from 'grammy';
 import Database from 'better-sqlite3';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -14,11 +14,19 @@ const SYSTEM_PROMPT_PARTS = [
   '/home/claude/claudes-world/agents/narrator/narrative-writing-guide.md',
 ];
 
-const USER_PROMPT = `Rewrite the source provided via stdin as a serious origin-story narrative suitable for text-to-speech playback.
-Target length: medium (approximately 600-900 words of output).
+const BASE_USER_PROMPT = `Rewrite the source provided via stdin as a serious origin-story narrative suitable for text-to-speech playback.
 Respond ONLY with the narrative prose — do not write files, do not include preamble, do not add commentary at the end.`;
 
+const LENGTH_INSTRUCTIONS: Record<'short' | 'medium' | 'full', string> = {
+  short: 'Target length: short (approximately 200-400 words of output).',
+  medium: 'Target length: medium (approximately 600-900 words of output).',
+  full: 'Target length: full length (approximately 1200-1800 words of output).',
+};
+
 const tracer = getTracer('narrator');
+
+// Module-scoped map so callback handler can clearTimeout by jobId
+const pendingTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
 function userFacingError(err: unknown): string {
   const msg = String(err);
@@ -63,146 +71,234 @@ export function createNarratorHandler(db: Database.Database) {
 
     const jobId = randomUUID();
     const now = Date.now();
+    const chatId = ctx.chat!.id;
 
-    // 2. Insert jobs row
+    // 2. Insert jobs row — length NULL until user chooses (or timeout defaults to medium)
     db.prepare(`
       INSERT INTO jobs (id, handler, chat_id, user_id, started_at, status, source_kind, tone, shape, length)
-      VALUES (?, 'narrator', ?, ?, ?, 'active', 'text', 'serious', 'origin-story', 'medium')
-    `).run(jobId, ctx.chat?.id ?? userId, userId, now);
+      VALUES (?, 'narrator', ?, ?, ?, 'active', 'text', 'serious', 'origin-story', NULL)
+    `).run(jobId, chatId, userId, now);
 
-    // Best-effort ack (don't abort job if ack fails)
+    // 3. Write source to temp file so continueNarration can read it after the callback
+    const sourceTmpFile = path.join(config.narrator.tmpDir, `narrator-src-${jobId}`);
+    await fs.writeFile(sourceTmpFile, sourceText);
+
+    // 4. Send inline keyboard as ack
+    const keyboard = new InlineKeyboard()
+      .text('Short (~2min)', `length:${jobId}:short`)
+      .text('Medium (default)', `length:${jobId}:medium`)
+      .text('Full length', `length:${jobId}:full`);
+
     let ackMessageId: number | undefined;
-    const chatId = ctx.chat!.id;
     try {
-      const ackMsg = await ctx.reply('Got your text. Generating narration...', {
+      const ackMsg = await ctx.reply('Got your text. Choose a length:', {
         reply_parameters: { message_id: ctx.message!.message_id },
+        reply_markup: keyboard,
       });
       ackMessageId = ackMsg.message_id;
     } catch (ackErr) {
       console.warn('narrator: ack send failed (best-effort):', ackErr);
     }
 
-    // Typing indicator — record_voice shows "recording voice message..."
-    let typingInterval: ReturnType<typeof setInterval> | undefined;
-    try {
-      await ctx.api.sendChatAction(chatId, 'record_voice');
-    } catch { /* ignore */ }
-    typingInterval = setInterval(async () => {
-      try {
-        await ctx.api.sendChatAction(chatId, 'record_voice');
-      } catch {
-        // On failure, clear interval, don't retry
-        clearInterval(typingInterval);
-        typingInterval = undefined;
-      }
-    }, 4000);
+    // 5. Record pending length choice
+    const expiresAt = Date.now() + config.narrator.lengthTimeoutMs;
+    if (ackMessageId) {
+      db.prepare(`
+        INSERT INTO pending_length_choices (job_id, chat_id, keyboard_msg_id, source_tmpfile, tone_prefix, shape_prefix, expires_at)
+        VALUES (?, ?, ?, ?, NULL, NULL, ?)
+      `).run(jobId, chatId, ackMessageId, sourceTmpFile, expiresAt);
+    }
 
-    let sysTmpFile: string | null = null;
-
-    try {
-      // 3. Build system prompt file
-      sysTmpFile = path.join(config.narrator.tmpDir, `narrator-sys-${jobId}.md`);
-      const parts = await Promise.all(SYSTEM_PROMPT_PARTS.map(p => fs.readFile(p, 'utf8')));
-      await fs.writeFile(sysTmpFile, parts.join('\n\n---\n\n'));
-
-      // 4. Spawn narrator subprocess — wrapped in OTEL span
-      const result = await withSpan(tracer, 'rewrite.sonnet', {
-        job_id: jobId,
-        chat_id: String(ctx.chat?.id ?? userId),
-        user_id: String(userId),
-        handler_name: 'narrator',
-        claude_model: config.narrator.rewriteModel,
-      }, async (span) => {
-        const r = await spawnNarrator({
-          runScript: config.narrator.agentRunScript,
-          model: config.narrator.rewriteModel,
-          sysFile: sysTmpFile!,
-          sourceText,
-          timeout: config.narrator.claudeTimeout,
-        });
-        span.setAttribute('claude_stop_reason', r.envelope.stop_reason ?? 'unknown');
-        const usage = (r.envelope as unknown as Record<string, unknown>)['usage'] as
-          | { input_tokens?: number; output_tokens?: number }
-          | undefined;
-        if (usage) {
-          span.setAttribute('claude_tokens_in', usage.input_tokens ?? 0);
-          span.setAttribute('claude_tokens_out', usage.output_tokens ?? 0);
-        }
-        return r;
-      });
-
-      const envelope = result.envelope;
-
-      // 5. Handle error envelope — mark failed and write error column
-      if (envelope.is_error) {
-        console.error('narrator: claude returned is_error', envelope);
-        try {
-          db.prepare(`UPDATE jobs SET status = 'failed', completed_at = ?, stop_reason = ?, error = ? WHERE id = ?`)
-            .run(Date.now(), envelope.stop_reason ?? null, envelope.result.slice(0, 500), jobId);
-        } catch { /* DB may be closing */ }
-        // Notify user via ack edit or new message
-        if (ackMessageId) {
-          try {
-            await ctx.api.editMessageText(chatId, ackMessageId,
-              `❌ Narration failed: Claude returned an error (${envelope.stop_reason ?? 'unknown'})`);
-          } catch { /* swallow */ }
-        } else {
-          await ctx.reply(`❌ Narration failed: Claude returned an error.`).catch(() => {});
-        }
-        return;
-      }
-
-      const narrative = envelope.result;
-      const stopReason = envelope.stop_reason ?? 'end_turn';
-
-      // 6. Record stop_reason only — status stays 'active' until deliverNarration succeeds
-      // This prevents a phantom completed row if delivery crashes after this point
-      db.prepare(`UPDATE jobs SET stop_reason = ? WHERE id = ?`).run(stopReason, jobId);
-
-      console.log(`narrator: job ${jobId} rewrite done — stop_reason=${stopReason}, starting delivery`);
-
-      // Guard: check job is still active before invoking paid TTS
-      const activeRow = db.prepare(`SELECT status FROM jobs WHERE id = ?`).get(jobId) as { status: string } | undefined;
-      if (!activeRow || activeRow.status !== 'active') {
-        console.warn(`narrator: job ${jobId} no longer active before delivery — skipping`);
-        return;
-      }
-
-      // 7. Deliver (writes story file, runs md-speak, sends audio, updates output_path/tts_chars/tts_usd)
-      await deliverNarration({
-        jobId,
-        userId,
-        narrative,
-        stopReason,
-        ctx,
-        db,
-        ackMessageId,
-      });
-
-    } catch (err: unknown) {
-      // Edit ack or send new message with user-friendly error
-      const friendlyMsg = `❌ ${userFacingError(err)}`;
+    // 6. Default timeout — use medium if user doesn't tap within lengthTimeoutMs
+    const timeoutHandle = setTimeout(async () => {
+      const still = db.prepare(`SELECT * FROM pending_length_choices WHERE job_id = ?`).get(jobId);
+      if (!still) return; // already handled by callback
+      db.prepare(`DELETE FROM pending_length_choices WHERE job_id = ?`).run(jobId);
+      pendingTimeouts.delete(jobId);
       if (ackMessageId) {
         try {
-          await ctx.api.editMessageText(chatId, ackMessageId, friendlyMsg);
+          await ctx.api.editMessageText(chatId, ackMessageId, 'Timed out — using default (medium)');
+        } catch { /* swallow */ }
+      }
+      await continueNarration(jobId, 'medium', ctx, db);
+    }, config.narrator.lengthTimeoutMs);
+
+    pendingTimeouts.set(jobId, timeoutHandle);
+  };
+}
+
+/**
+ * Continue narration after length selection (from callback or timeout).
+ * Contains the Claude rewrite + delivery logic.
+ */
+export async function continueNarration(
+  jobId: string,
+  length: 'short' | 'medium' | 'full',
+  ctx: Context,
+  db: Database.Database,
+): Promise<void> {
+  // Clear any pending timeout for this job (if called from callback)
+  const existingTimeout = pendingTimeouts.get(jobId);
+  if (existingTimeout !== undefined) {
+    clearTimeout(existingTimeout);
+    pendingTimeouts.delete(jobId);
+  }
+
+  const userId = ctx.from?.id;
+  if (!userId) return;
+
+  const chatId = ctx.chat?.id ?? (ctx.callbackQuery?.message?.chat.id) ?? userId;
+
+  // Update job row with chosen length
+  db.prepare(`UPDATE jobs SET length = ? WHERE id = ?`).run(length, jobId);
+
+  // Read source from tmpfile
+  const sourceTmpFile = path.join(config.narrator.tmpDir, `narrator-src-${jobId}`);
+  let sourceText: string;
+  try {
+    sourceText = await fs.readFile(sourceTmpFile, 'utf8');
+  } catch (err) {
+    console.error(`narrator: could not read source tmpfile for job ${jobId}:`, err);
+    try {
+      db.prepare(`UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ?`)
+        .run(Date.now(), `source tmpfile missing: ${String(err)}`, jobId);
+    } catch { /* DB may be closing */ }
+    return;
+  }
+
+  // Find the ack message id to update user on progress
+  const pendingRow = db.prepare(`SELECT keyboard_msg_id FROM pending_length_choices WHERE job_id = ?`).get(jobId) as
+    | { keyboard_msg_id: number }
+    | undefined;
+  // Note: pending row may already be deleted by the callback handler — that's fine
+  // We get ackMessageId from the callback-edited message (already shows "Rewriting in X mode…")
+  // We need it only if we need to edit again on error. The callback handler already edited it.
+
+  // Typing indicator — record_voice shows "recording voice message..."
+  let typingInterval: ReturnType<typeof setInterval> | undefined;
+  try {
+    await ctx.api.sendChatAction(chatId, 'record_voice');
+  } catch { /* ignore */ }
+  typingInterval = setInterval(async () => {
+    try {
+      await ctx.api.sendChatAction(chatId, 'record_voice');
+    } catch {
+      clearInterval(typingInterval);
+      typingInterval = undefined;
+    }
+  }, 4000);
+
+  let sysTmpFile: string | null = null;
+
+  // We need ackMessageId for error editing — look it up from pendingRow or skip
+  const ackMessageId = pendingRow?.keyboard_msg_id;
+
+  try {
+    // Build system prompt file
+    sysTmpFile = path.join(config.narrator.tmpDir, `narrator-sys-${jobId}.md`);
+    const parts = await Promise.all(SYSTEM_PROMPT_PARTS.map(p => fs.readFile(p, 'utf8')));
+    await fs.writeFile(sysTmpFile, parts.join('\n\n---\n\n'));
+
+    const userPrompt = `${BASE_USER_PROMPT}\n${LENGTH_INSTRUCTIONS[length]}`;
+
+    // Spawn narrator subprocess — wrapped in OTEL span
+    const result = await withSpan(tracer, 'rewrite.sonnet', {
+      job_id: jobId,
+      chat_id: String(chatId),
+      user_id: String(userId),
+      handler_name: 'narrator',
+      claude_model: config.narrator.rewriteModel,
+    }, async (span) => {
+      const r = await spawnNarrator({
+        runScript: config.narrator.agentRunScript,
+        model: config.narrator.rewriteModel,
+        sysFile: sysTmpFile!,
+        sourceText,
+        userPrompt,
+        timeout: config.narrator.claudeTimeout,
+      });
+      span.setAttribute('claude_stop_reason', r.envelope.stop_reason ?? 'unknown');
+      const usage = (r.envelope as unknown as Record<string, unknown>)['usage'] as
+        | { input_tokens?: number; output_tokens?: number }
+        | undefined;
+      if (usage) {
+        span.setAttribute('claude_tokens_in', usage.input_tokens ?? 0);
+        span.setAttribute('claude_tokens_out', usage.output_tokens ?? 0);
+      }
+      return r;
+    });
+
+    const envelope = result.envelope;
+
+    // Handle error envelope — mark failed and write error column
+    if (envelope.is_error) {
+      console.error('narrator: claude returned is_error', envelope);
+      try {
+        db.prepare(`UPDATE jobs SET status = 'failed', completed_at = ?, stop_reason = ?, error = ? WHERE id = ?`)
+          .run(Date.now(), envelope.stop_reason ?? null, envelope.result.slice(0, 500), jobId);
+      } catch { /* DB may be closing */ }
+      if (ackMessageId) {
+        try {
+          await ctx.api.editMessageText(chatId, ackMessageId,
+            `❌ Narration failed: Claude returned an error (${envelope.stop_reason ?? 'unknown'})`);
         } catch { /* swallow */ }
       } else {
-        await ctx.reply(friendlyMsg).catch(() => {});
+        await ctx.reply(`❌ Narration failed: Claude returned an error.`).catch(() => {});
       }
-      // Update job row to failed — any unhandled throw reaches here
-      try {
-        db.prepare(`
-          UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ?
-        `).run(Date.now(), String(err), jobId);
-      } catch { /* DB may be closing */ }
-      throw err;  // re-throw so router crash boundary logs it
-    } finally {
-      clearInterval(typingInterval);
-      if (sysTmpFile) {
-        try { await fs.unlink(sysTmpFile); } catch { /* already gone */ }
-      }
+      return;
     }
-  };
+
+    const narrative = envelope.result;
+    const stopReason = envelope.stop_reason ?? 'end_turn';
+
+    // Record stop_reason only — status stays 'active' until deliverNarration succeeds
+    db.prepare(`UPDATE jobs SET stop_reason = ? WHERE id = ?`).run(stopReason, jobId);
+
+    console.log(`narrator: job ${jobId} rewrite done — stop_reason=${stopReason}, starting delivery`);
+
+    // Guard: check job is still active before invoking paid TTS
+    const activeRow = db.prepare(`SELECT status FROM jobs WHERE id = ?`).get(jobId) as { status: string } | undefined;
+    if (!activeRow || activeRow.status !== 'active') {
+      console.warn(`narrator: job ${jobId} no longer active before delivery — skipping`);
+      return;
+    }
+
+    // Deliver (writes story file, runs md-speak, sends audio, updates output_path/tts_chars/tts_usd)
+    await deliverNarration({
+      jobId,
+      userId,
+      narrative,
+      stopReason,
+      ctx,
+      db,
+      ackMessageId,
+    });
+
+  } catch (err: unknown) {
+    // Edit ack or send new message with user-friendly error
+    const friendlyMsg = `❌ ${userFacingError(err)}`;
+    if (ackMessageId) {
+      try {
+        await ctx.api.editMessageText(chatId, ackMessageId, friendlyMsg);
+      } catch { /* swallow */ }
+    } else {
+      await ctx.reply(friendlyMsg).catch(() => {});
+    }
+    // Update job row to failed
+    try {
+      db.prepare(`
+        UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ?
+      `).run(Date.now(), String(err), jobId);
+    } catch { /* DB may be closing */ }
+    throw err; // re-throw so router crash boundary logs it
+  } finally {
+    clearInterval(typingInterval);
+    if (sysTmpFile) {
+      try { await fs.unlink(sysTmpFile); } catch { /* already gone */ }
+    }
+    // Clean up source tmpfile
+    try { await fs.unlink(sourceTmpFile); } catch { /* already gone */ }
+  }
 }
 
 interface SpawnOptions {
@@ -210,6 +306,7 @@ interface SpawnOptions {
   model: string;
   sysFile: string;
   sourceText: string;
+  userPrompt: string;
   timeout: number;
 }
 
@@ -220,7 +317,7 @@ interface SpawnResult {
 
 async function spawnNarrator(opts: SpawnOptions): Promise<SpawnResult> {
   const args = [
-    '-p', USER_PROMPT,
+    '-p', opts.userPrompt,
     '--output-format', 'json',
     '--append-system-prompt-file', opts.sysFile,
     '--model', opts.model,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ import { createBot } from './bot-factory.js';
 import { openDatabase } from './state/db.js';
 import { startupSweep } from './state/cleanup.js';
 import { registerHandlers } from './router.js';
-import { createNarratorHandler } from './handlers/narrator.js';
+import { createNarratorHandler, continueNarration } from './handlers/narrator.js';
+import { createLengthCallbackHandler } from './handlers/narrator-callback.js';
 
 async function main(): Promise<void> {
   const db = openDatabase(config.dobotDbPath);
@@ -15,6 +16,9 @@ async function main(): Promise<void> {
 
   registerHandlers(narratorBot, {
     narrator: createNarratorHandler(db),
+    narratorCallback: createLengthCallbackHandler(db, (jobId, length, ctx) =>
+      continueNarration(jobId, length, ctx, db)
+    ),
   });
 
   // Graceful shutdown — idempotent guard ensures concurrent SIGINT+SIGTERM

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,7 +3,7 @@ import { getTracer } from './lib/otel.js';
 
 type Handler = (ctx: Context) => Promise<void>;
 
-export function registerHandlers(bot: Bot, handlers: { narrator: Handler }): void {
+export function registerHandlers(bot: Bot, handlers: { narrator: Handler; narratorCallback: Handler }): void {
   // Handler crash boundary: every handler wrapped in try/catch
   bot.on('message', async (ctx) => {
     const tracer = getTracer('narrator');
@@ -12,6 +12,21 @@ export function registerHandlers(bot: Bot, handlers: { narrator: Handler }): voi
       await handlers.narrator(ctx);
     } catch (err) {
       console.error('narrator handler threw', err);
+      span.recordException(err as Error);
+      span.setStatus({ code: 2 /* ERROR */ });
+      // Do NOT re-throw — propagation would kill the bot loop
+    } finally {
+      span.end();
+    }
+  });
+
+  bot.on('callback_query', async (ctx) => {
+    const tracer = getTracer('narrator');
+    const span = tracer.startSpan('handler.narrator.callback');
+    try {
+      await handlers.narratorCallback(ctx);
+    } catch (err) {
+      console.error('narrator callback handler threw', err);
       span.recordException(err as Error);
       span.setStatus({ code: 2 /* ERROR */ });
       // Do NOT re-throw — propagation would kill the bot loop

--- a/test/handlers/narrator-callback.test.ts
+++ b/test/handlers/narrator-callback.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { createLengthCallbackHandler } from '../../src/handlers/narrator-callback.js';
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS jobs (
+      id              TEXT PRIMARY KEY,
+      handler         TEXT NOT NULL,
+      chat_id         INTEGER NOT NULL,
+      user_id         INTEGER NOT NULL,
+      started_at      INTEGER NOT NULL,
+      completed_at    INTEGER,
+      status          TEXT NOT NULL,
+      source_kind     TEXT,
+      tone            TEXT,
+      shape           TEXT,
+      length          TEXT,
+      output_path     TEXT,
+      subprocess_pid  INTEGER,
+      tts_chars       INTEGER,
+      tts_usd         REAL,
+      stop_reason     TEXT,
+      error           TEXT
+    );
+    CREATE TABLE IF NOT EXISTS pending_length_choices (
+      job_id          TEXT PRIMARY KEY,
+      chat_id         INTEGER NOT NULL,
+      keyboard_msg_id INTEGER NOT NULL,
+      source_tmpfile  TEXT NOT NULL,
+      tone_prefix     TEXT,
+      shape_prefix    TEXT,
+      expires_at      INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES jobs(id)
+    );
+  `);
+  return db;
+}
+
+function insertJob(db: Database.Database, jobId: string, chatId = 100) {
+  db.prepare(`
+    INSERT INTO jobs (id, handler, chat_id, user_id, started_at, status)
+    VALUES (?, 'narrator', ?, 1, ?, 'active')
+  `).run(jobId, chatId, Date.now());
+}
+
+function insertPending(db: Database.Database, jobId: string, chatId = 100, keyboardMsgId = 99) {
+  db.prepare(`
+    INSERT INTO pending_length_choices (job_id, chat_id, keyboard_msg_id, source_tmpfile, tone_prefix, shape_prefix, expires_at)
+    VALUES (?, ?, ?, '/tmp/narrator-src-test', NULL, NULL, ?)
+  `).run(jobId, chatId, keyboardMsgId, Date.now() + 20000);
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    callbackQuery: { data: '' },
+    from: { id: 1 },
+    chat: { id: 100 },
+    message: { message_id: 42 },
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+    api: {
+      editMessageReplyMarkup: vi.fn().mockResolvedValue(undefined),
+      editMessageText: vi.fn().mockResolvedValue(undefined),
+    },
+    reply: vi.fn().mockResolvedValue({ message_id: 99 }),
+    ...overrides,
+  };
+}
+
+describe('narratorCallbackHandler', () => {
+  let db: Database.Database;
+  let onLengthChosen: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    onLengthChosen = vi.fn().mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('1. Valid callback (length:jobId:medium) with pending row — deletes row, edits message, calls onLengthChosen', async () => {
+    const jobId = 'job-test-1';
+    insertJob(db, jobId);
+    insertPending(db, jobId, 100, 99);
+
+    const ctx = makeCtx({
+      callbackQuery: { data: `length:${jobId}:medium` },
+    });
+
+    const handler = createLengthCallbackHandler(db, onLengthChosen);
+    await handler(ctx as never);
+
+    // Pending row should be deleted
+    const row = db.prepare(`SELECT * FROM pending_length_choices WHERE job_id = ?`).get(jobId);
+    expect(row).toBeUndefined();
+
+    // Edit message called
+    expect(ctx.editMessageText).toHaveBeenCalledWith(expect.stringContaining('medium'));
+
+    // Answer callback
+    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+
+    // onLengthChosen invoked with correct args
+    expect(onLengthChosen).toHaveBeenCalledWith(jobId, 'medium', ctx);
+  });
+
+  it('2. Expired/missing callback_data (no "length:" prefix) — answers callback, no crash', async () => {
+    const ctx = makeCtx({
+      callbackQuery: { data: 'some-other-data' },
+    });
+
+    const handler = createLengthCallbackHandler(db, onLengthChosen);
+    await expect(handler(ctx as never)).resolves.not.toThrow();
+
+    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+    expect(onLengthChosen).not.toHaveBeenCalled();
+  });
+
+  it('2b. Malformed data (too many/few parts) — answers callback with error text, no crash', async () => {
+    const ctx = makeCtx({
+      callbackQuery: { data: 'length:onlytwoparts' },
+    });
+
+    const handler = createLengthCallbackHandler(db, onLengthChosen);
+    await expect(handler(ctx as never)).resolves.not.toThrow();
+
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: 'Invalid selection.' });
+    expect(onLengthChosen).not.toHaveBeenCalled();
+  });
+
+  it('3. Unknown jobId (stale keyboard) — edits message to expired text, answers callback, no crash', async () => {
+    const jobId = 'job-nonexistent';
+
+    const ctx = makeCtx({
+      callbackQuery: { data: `length:${jobId}:short` },
+    });
+
+    const handler = createLengthCallbackHandler(db, onLengthChosen);
+    await expect(handler(ctx as never)).resolves.not.toThrow();
+
+    expect(ctx.editMessageText).toHaveBeenCalledWith(expect.stringContaining('expired'));
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: 'This selection has expired.' });
+    expect(onLengthChosen).not.toHaveBeenCalled();
+  });
+
+  it('4. Sweep: 2 other pending keyboards for same chat_id get their reply_markup removed', async () => {
+    const jobId = 'job-main';
+    const jobIdOther1 = 'job-other-1';
+    const jobIdOther2 = 'job-other-2';
+    const chatId = 100;
+
+    insertJob(db, jobId, chatId);
+    insertJob(db, jobIdOther1, chatId);
+    insertJob(db, jobIdOther2, chatId);
+
+    insertPending(db, jobId, chatId, 99);
+    insertPending(db, jobIdOther1, chatId, 201);
+    insertPending(db, jobIdOther2, chatId, 202);
+
+    const ctx = makeCtx({
+      callbackQuery: { data: `length:${jobId}:full` },
+    });
+
+    const handler = createLengthCallbackHandler(db, onLengthChosen);
+    await handler(ctx as never);
+
+    // Both other keyboards should have reply_markup removed
+    expect(ctx.api.editMessageReplyMarkup).toHaveBeenCalledTimes(2);
+    const calls = vi.mocked(ctx.api.editMessageReplyMarkup).mock.calls;
+    const removedMsgIds = calls.map(c => c[1]);
+    expect(removedMsgIds).toContain(201);
+    expect(removedMsgIds).toContain(202);
+
+    // Other pending rows should be deleted from DB
+    const other1 = db.prepare(`SELECT * FROM pending_length_choices WHERE job_id = ?`).get(jobIdOther1);
+    const other2 = db.prepare(`SELECT * FROM pending_length_choices WHERE job_id = ?`).get(jobIdOther2);
+    expect(other1).toBeUndefined();
+    expect(other2).toBeUndefined();
+
+    // onLengthChosen still called for main job
+    expect(onLengthChosen).toHaveBeenCalledWith(jobId, 'full', ctx);
+  });
+
+  it('5. Invalid length value — answers callback with error, no crash, onLengthChosen not called', async () => {
+    const jobId = 'job-invalid-len';
+    insertJob(db, jobId);
+    insertPending(db, jobId);
+
+    const ctx = makeCtx({
+      callbackQuery: { data: `length:${jobId}:superlong` },
+    });
+
+    const handler = createLengthCallbackHandler(db, onLengthChosen);
+    await expect(handler(ctx as never)).resolves.not.toThrow();
+
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: 'Invalid length.' });
+    expect(onLengthChosen).not.toHaveBeenCalled();
+  });
+});

--- a/test/handlers/narrator.test.ts
+++ b/test/handlers/narrator.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../src/config.js', () => ({
       tmpDir: '/tmp',
       maxJobsPerHour: 10,
       maxDailyTtsUsd: 5.0,
+      lengthTimeoutMs: 20000,
     },
   },
 }));
@@ -43,19 +44,20 @@ vi.mock('../../src/delivery/narrator.js', () => ({
   deliverNarration: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>();
-  return {
-    ...actual,
-    readFile: vi.fn().mockResolvedValue('mock system prompt'),
+vi.mock('node:fs/promises', () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue('mock source text'),
     writeFile: vi.fn().mockResolvedValue(undefined),
     unlink: vi.fn().mockResolvedValue(undefined),
-  };
-});
+  },
+  readFile: vi.fn().mockResolvedValue('mock source text'),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { spawnClaudeWithRetry } from '../../src/lib/claude-subprocess.js';
 import { deliverNarration } from '../../src/delivery/narrator.js';
-import { createNarratorHandler } from '../../src/handlers/narrator.js';
+import { createNarratorHandler, continueNarration } from '../../src/handlers/narrator.js';
 
 function createTestDb(): Database.Database {
   const db = new Database(':memory:');
@@ -79,6 +81,16 @@ function createTestDb(): Database.Database {
       tts_failed      INTEGER NOT NULL DEFAULT 0,
       stop_reason     TEXT,
       error           TEXT
+    );
+    CREATE TABLE IF NOT EXISTS pending_length_choices (
+      job_id          TEXT PRIMARY KEY,
+      chat_id         INTEGER NOT NULL,
+      keyboard_msg_id INTEGER NOT NULL,
+      source_tmpfile  TEXT NOT NULL,
+      tone_prefix     TEXT,
+      shape_prefix    TEXT,
+      expires_at      INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES jobs(id)
     );
     CREATE TABLE IF NOT EXISTS rate_limits_hourly (
       id        INTEGER PRIMARY KEY,
@@ -112,6 +124,13 @@ function makeCtx(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function insertJob(db: Database.Database, jobId: string, chatId = 100) {
+  db.prepare(`
+    INSERT INTO jobs (id, handler, chat_id, user_id, started_at, status)
+    VALUES (?, 'narrator', ?, 1, ?, 'active')
+  `).run(jobId, chatId, Date.now());
+}
+
 const mockSuccessEnvelope = {
   envelope: {
     is_error: false,
@@ -121,7 +140,7 @@ const mockSuccessEnvelope = {
   retried: false,
 };
 
-describe('narratorHandler — ack + typing indicator', () => {
+describe('narratorHandler — keyboard ack (message phase)', () => {
   let db: Database.Database;
 
   beforeEach(() => {
@@ -131,38 +150,76 @@ describe('narratorHandler — ack + typing indicator', () => {
     vi.mocked(deliverNarration).mockResolvedValue(undefined);
   });
 
-  it('1. Ack sent before spawn', async () => {
-    const order: string[] = [];
-    vi.mocked(spawnClaudeWithRetry).mockImplementation(async () => {
-      order.push('spawn');
-      return mockSuccessEnvelope;
-    });
-
-    const ctx = makeCtx({
-      reply: vi.fn().mockImplementation(async () => {
-        order.push('reply');
-        return { message_id: 99 };
-      }),
-    });
-
-    const handler = createNarratorHandler(db);
-    await handler(ctx as never);
-
-    // reply (ack) must come before spawn
-    const replyIdx = order.indexOf('reply');
-    const spawnIdx = order.indexOf('spawn');
-    expect(replyIdx).toBeGreaterThanOrEqual(0);
-    expect(spawnIdx).toBeGreaterThanOrEqual(0);
-    expect(replyIdx).toBeLessThan(spawnIdx);
-  });
-
-  it('2. Typing interval cleared on success', async () => {
-    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
-    const setIntervalSpy = vi.spyOn(global, 'setInterval');
-
+  it('1. Keyboard sent as ack (no spawn in message phase)', async () => {
     const ctx = makeCtx();
     const handler = createNarratorHandler(db);
     await handler(ctx as never);
+
+    // reply called with keyboard markup
+    expect(ctx.reply).toHaveBeenCalledWith(
+      expect.stringContaining('length'),
+      expect.objectContaining({ reply_markup: expect.anything() })
+    );
+
+    // spawn NOT called in message phase — user must choose length first
+    expect(spawnClaudeWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('2. Pending row inserted after ack', async () => {
+    const ctx = makeCtx();
+    const handler = createNarratorHandler(db);
+    await handler(ctx as never);
+
+    const rows = db.prepare(`SELECT * FROM pending_length_choices`).all();
+    expect(rows.length).toBe(1);
+  });
+
+  it('3. Ack failure does not abort — pending row still inserted', async () => {
+    const ctx = makeCtx({
+      reply: vi.fn().mockRejectedValue(new Error('Telegram API down')),
+    });
+
+    const handler = createNarratorHandler(db);
+    // ack fail is best-effort — handler should not throw
+    await expect(handler(ctx as never)).resolves.not.toThrow();
+
+    // When ack fails, ackMessageId is undefined, so no pending row inserted
+    // (guard: `if (ackMessageId)` wraps the insert)
+    const rows = db.prepare(`SELECT * FROM pending_length_choices`).all();
+    // No row when ackMessageId unknown — that's correct per spec
+    expect(rows.length).toBe(0);
+  });
+
+  it('4. Job row inserted with NULL length', async () => {
+    const ctx = makeCtx();
+    const handler = createNarratorHandler(db);
+    await handler(ctx as never);
+
+    const job = db.prepare(`SELECT * FROM jobs`).get() as { length: string | null } | undefined;
+    expect(job).toBeTruthy();
+    expect(job?.length).toBeNull();
+  });
+});
+
+describe('continueNarration — spawn + delivery phase', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    vi.clearAllMocks();
+    vi.mocked(spawnClaudeWithRetry).mockResolvedValue(mockSuccessEnvelope);
+    vi.mocked(deliverNarration).mockResolvedValue(undefined);
+  });
+
+  it('1. Typing interval cleared on success', async () => {
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    const setIntervalSpy = vi.spyOn(global, 'setInterval');
+
+    const jobId = 'job-typing-success';
+    insertJob(db, jobId);
+
+    const ctx = makeCtx();
+    await continueNarration(jobId, 'medium', ctx as never, db);
 
     expect(setIntervalSpy).toHaveBeenCalled();
     expect(clearIntervalSpy).toHaveBeenCalled();
@@ -171,15 +228,16 @@ describe('narratorHandler — ack + typing indicator', () => {
     setIntervalSpy.mockRestore();
   });
 
-  it('3. Typing interval cleared on error', async () => {
+  it('2. Typing interval cleared on error', async () => {
     const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
     const setIntervalSpy = vi.spyOn(global, 'setInterval');
     vi.mocked(spawnClaudeWithRetry).mockRejectedValue(new Error('something went wrong'));
 
+    const jobId = 'job-typing-error';
+    insertJob(db, jobId);
+
     const ctx = makeCtx();
-    const handler = createNarratorHandler(db);
-    // handler re-throws
-    await expect(handler(ctx as never)).rejects.toThrow('something went wrong');
+    await expect(continueNarration(jobId, 'medium', ctx as never, db)).rejects.toThrow('something went wrong');
 
     expect(setIntervalSpy).toHaveBeenCalled();
     expect(clearIntervalSpy).toHaveBeenCalled();
@@ -188,18 +246,20 @@ describe('narratorHandler — ack + typing indicator', () => {
     setIntervalSpy.mockRestore();
   });
 
-  it('4. Error path sends user-friendly message — auth error maps to "temporarily unavailable"', async () => {
+  it('3. Error path sends user-friendly message — auth error maps to "temporarily unavailable"', async () => {
     vi.mocked(spawnClaudeWithRetry).mockRejectedValue(
       new Error('not logged in — please run /login first')
     );
 
-    const ctx = makeCtx();
-    const handler = createNarratorHandler(db);
-    await expect(handler(ctx as never)).rejects.toThrow();
+    const jobId = 'job-auth-err';
+    insertJob(db, jobId);
 
-    // The ack edit must show user-friendly text, not the raw error
-    const editCalls = vi.mocked(ctx.api.editMessageText).mock.calls;
-    const allMessages = editCalls.map(c => c[2] as string);
+    const ctx = makeCtx();
+    await expect(continueNarration(jobId, 'medium', ctx as never, db)).rejects.toThrow();
+
+    // Since no ackMessageId, it falls back to ctx.reply
+    const replyCalls = vi.mocked(ctx.reply).mock.calls;
+    const allMessages = replyCalls.map(c => c[0] as string);
     const anyFriendly = allMessages.some(m => m.includes('temporarily unavailable'));
     expect(anyFriendly).toBe(true);
 
@@ -208,18 +268,31 @@ describe('narratorHandler — ack + typing indicator', () => {
     expect(anyRaw).toBe(false);
   });
 
-  it('5. Ack failure does not abort job — spawn still called', async () => {
-    vi.mocked(spawnClaudeWithRetry).mockResolvedValue(mockSuccessEnvelope);
+  it('4. Spawn called with correct length instructions', async () => {
+    const jobId = 'job-len-check';
+    insertJob(db, jobId);
 
-    const ctx = makeCtx({
-      reply: vi.fn().mockRejectedValue(new Error('Telegram API down')),
-    });
+    const ctx = makeCtx();
+    await continueNarration(jobId, 'short', ctx as never, db);
 
-    const handler = createNarratorHandler(db);
-    // best-effort ack failure is swallowed; handler should complete without error
-    await expect(handler(ctx as never)).resolves.not.toThrow();
-
-    // Spawn was still called despite ack failure
     expect(spawnClaudeWithRetry).toHaveBeenCalled();
+    const callArgs = vi.mocked(spawnClaudeWithRetry).mock.calls[0];
+    // args[1] is the args array — -p prompt is first pair
+    const argsArray = callArgs[1] as string[];
+    const promptIdx = argsArray.indexOf('-p');
+    expect(promptIdx).toBeGreaterThanOrEqual(0);
+    const prompt = argsArray[promptIdx + 1];
+    expect(prompt).toContain('200-400');
+  });
+
+  it('5. Job length column updated to chosen value', async () => {
+    const jobId = 'job-len-col';
+    insertJob(db, jobId);
+
+    const ctx = makeCtx();
+    await continueNarration(jobId, 'full', ctx as never, db);
+
+    const job = db.prepare(`SELECT length FROM jobs WHERE id = ?`).get(jobId) as { length: string };
+    expect(job.length).toBe('full');
   });
 });

--- a/test/handlers/narrator.test.ts
+++ b/test/handlers/narrator.test.ts
@@ -174,7 +174,7 @@ describe('narratorHandler — keyboard ack (message phase)', () => {
     expect(rows.length).toBe(1);
   });
 
-  it('3. Ack failure does not abort — pending row still inserted', async () => {
+  it('3. Ack failure does not abort — pending row inserted with keyboard_msg_id=0', async () => {
     const ctx = makeCtx({
       reply: vi.fn().mockRejectedValue(new Error('Telegram API down')),
     });
@@ -183,11 +183,10 @@ describe('narratorHandler — keyboard ack (message phase)', () => {
     // ack fail is best-effort — handler should not throw
     await expect(handler(ctx as never)).resolves.not.toThrow();
 
-    // When ack fails, ackMessageId is undefined, so no pending row inserted
-    // (guard: `if (ackMessageId)` wraps the insert)
-    const rows = db.prepare(`SELECT * FROM pending_length_choices`).all();
-    // No row when ackMessageId unknown — that's correct per spec
-    expect(rows.length).toBe(0);
+    // Row is still inserted (keyboard_msg_id=0) so timeout can fire continueNarration
+    const rows = db.prepare(`SELECT * FROM pending_length_choices`).all() as { keyboard_msg_id: number }[];
+    expect(rows.length).toBe(1);
+    expect(rows[0].keyboard_msg_id).toBe(0);
   });
 
   it('4. Job row inserted with NULL length', async () => {


### PR DESCRIPTION
Closes #34

## Summary

Adds length selection UX to narrator:
- InlineKeyboard (Short/Medium [default]/Full) sent with ack message
- `callback_data` includes jobId nonce — prevents stale-keyboard cross-talk
- On tap: verify nonce, sweep other pending keyboards for chat, clear timeout, proceed with chosen length
- On timeout (default 20s via `NARRATOR_LENGTH_TIMEOUT`): edit to "Timed out — using default (medium)", continue with medium
- `continueNarration()` exported — called by both callback handler and timeout
- `pending_length_choices` row always inserted (even on ack failure, `keyboard_msg_id=0`) so timeout always fires
- `pendingTimeouts` Map: callback calls `clearTimeout` to prevent double-fire
- Jobs INSERT with `length=NULL`; UPDATE in `continueNarration` to chosen value
- `router.ts`: `callback_query` handler with OTEL span + crash boundary

## Swarm review

- Tier 1 (Claude subagent): found 2 bugs (ack-fail path leaked job + tmpfile; stale Map entry) — fixed in second commit, re-reviewed CLEAN
- Tier 2 (Codex): reviewed codebase, output truncated before final verdict (tooling limit)

## Test results

60 tests across 7 files — all pass.
- `test/handlers/narrator-callback.test.ts`: 5 new tests (valid callback, expired data, unknown jobId, stale sweep, invalid length)
- `test/handlers/narrator.test.ts`: updated for new 2-phase flow (keyboard send + continueNarration)

Part of #33.