### PR TITLE
fix(delivery): use t.me mini-app deep-link for Pocket Console button (#45)

### DIFF
--- a/src/delivery/narrator.ts
+++ b/src/delivery/narrator.ts
@@ -51,7 +51,7 @@ export async function deliverNarration(opts: DeliveryOptions): Promise<void> {
   await fs.writeFile(mdPath, finalNarrative);
 
   // 2. Construct CPC deep link directly from mdPath
-  const deepLink: string = `https://cpc.claude.do/#file=${encodeURIComponent(mdPath)}`;
+  const deepLink: string = `https://t.me/claude_do_bot/pocket?startapp=${encodeURIComponent(mdPath)}`;
 
   // 3. Invoke md-speak --no-describe to generate audio
   const mp3Path = mdPath.replace(/\.md$/, '.mp3');


### PR DESCRIPTION
Closes #45

Replace cpc.claude.do browser URL with t.me/claude_do_bot/pocket?startapp=<path> so the Pocket Console button opens inside Telegram with initData auth context.

One-line fix in src/delivery/narrator.ts line 54.