### PR TITLE
fix(narrator): DM-only filter — reject group messages (#47)

### DIFF
--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -42,6 +42,9 @@ export function createNarratorHandler(db: Database.Database) {
     // 1. Filter — silently reject if not in allowlist
     if (!config.narrator.allowedUserIds.has(userId)) return;
 
+    // 2. DM-only — silently reject group/supergroup/channel messages (#47)
+    if (ctx.chat?.type !== "private") return;
+
     const sourceText = ctx.message?.text;
     if (!sourceText) return;
 

--- a/test/handlers/narrator.test.ts
+++ b/test/handlers/narrator.test.ts
@@ -101,7 +101,7 @@ function createTestDb(): Database.Database {
 function makeCtx(overrides: Record<string, unknown> = {}) {
   return {
     from: { id: 1 },
-    chat: { id: 100 },
+    chat: { id: 100, type: 'private' },
     message: { text: 'Hello world story', message_id: 42 },
     reply: vi.fn().mockResolvedValue({ message_id: 99 }),
     api: {


### PR DESCRIPTION
Closes #47

## Summary
- Narrator handler now silently rejects group/supergroup/channel messages
- One-line guard: `if (ctx.chat?.type !== "private") return;` added immediately after the user allowlist check
- Test mock updated to include `chat.type: 'private'`

## Verification
- `pnpm run build` — clean
- `pnpm run test` — 50/50 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)