### PR TITLE
feat(narrator): rebuild length timeouts on startup, fix orphan sweep (#35)

### DIFF
--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -25,8 +25,8 @@ const LENGTH_INSTRUCTIONS: Record<'short' | 'medium' | 'full', string> = {
 
 const tracer = getTracer('narrator');
 
-// Module-scoped map so callback handler can clearTimeout by jobId
-const pendingTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+// Module-scoped map so callback handler and startup rebuild can clearTimeout by jobId
+export const pendingTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
 function userFacingError(err: unknown): string {
   const msg = String(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import 'dotenv/config';
 import { config } from './config.js';
 import { createBot } from './bot-factory.js';
 import { openDatabase } from './state/db.js';
-import { startupSweep } from './state/cleanup.js';
+import { startupSweep, rebuildPendingTimeouts } from './state/cleanup.js';
 import { registerHandlers } from './router.js';
 import { createNarratorHandler, continueNarration } from './handlers/narrator.js';
 import { createLengthCallbackHandler } from './handlers/narrator-callback.js';
@@ -13,6 +13,12 @@ async function main(): Promise<void> {
   await startupSweep(db);
 
   const narratorBot = createBot(config.telegramNarratorBotToken);
+
+  // Rebuild setTimeout handles for in-window pending choices that survived the restart.
+  // Must run after bot creation (needs api + me) but before bot.start().
+  const me = await narratorBot.api.getMe();
+  rebuildPendingTimeouts(db, narratorBot.api, me,
+    (jobId, length, ctx) => continueNarration(jobId, length, ctx, db));
 
   registerHandlers(narratorBot, {
     narrator: createNarratorHandler(db),

--- a/src/state/cleanup.ts
+++ b/src/state/cleanup.ts
@@ -1,16 +1,47 @@
+import { Context, Api } from 'grammy';
+import type { UserFromGetMe, Update } from 'grammy/types';
 import Database from 'better-sqlite3';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { pendingTimeouts } from '../handlers/narrator.js';
+
+interface PendingRow {
+  job_id: string;
+  chat_id: number;
+  keyboard_msg_id: number;
+  source_tmpfile: string;
+  expires_at: number;
+}
+
+interface JobRow {
+  user_id: number;
+}
 
 export async function startupSweep(db: Database.Database): Promise<void> {
   // 1. Null stale subprocess PIDs
   db.prepare("UPDATE jobs SET subprocess_pid = NULL WHERE status = 'active'").run();
 
-  // 2. Mark orphaned active jobs failed
-  db.prepare("UPDATE jobs SET status = 'failed', error = 'orphaned on restart' WHERE status = 'active'").run();
+  // 2. Mark orphaned active jobs failed — exclude jobs with in-window pending choices
+  //    (those will get timeouts rebuilt by rebuildPendingTimeouts)
+  const now = Date.now();
+  const inWindow = db.prepare(
+    "SELECT job_id FROM pending_length_choices WHERE expires_at >= ?"
+  ).all(now) as { job_id: string }[];
+  const inWindowIds = inWindow.map(r => r.job_id);
+
+  if (inWindowIds.length > 0) {
+    // SQLite doesn't support parameterised IN with arrays via better-sqlite3 directly,
+    // so build placeholders
+    const placeholders = inWindowIds.map(() => '?').join(',');
+    db.prepare(
+      `UPDATE jobs SET status = 'failed', error = 'orphaned on restart'
+       WHERE status = 'active' AND id NOT IN (${placeholders})`
+    ).run(...inWindowIds);
+  } else {
+    db.prepare("UPDATE jobs SET status = 'failed', error = 'orphaned on restart' WHERE status = 'active'").run();
+  }
 
   // 3. Delete expired pending choices + unlink temp files
-  const now = Date.now();
   const expired = db.prepare(
     "SELECT source_tmpfile FROM pending_length_choices WHERE expires_at < ?"
   ).all(now) as { source_tmpfile: string }[];
@@ -34,4 +65,76 @@ export async function startupSweep(db: Database.Database): Promise<void> {
       }
     }
   } catch { /* tmp dir not accessible */ }
+}
+
+/**
+ * Rebuild setTimeout handles for pending_length_choices that are still within
+ * their expiry window. Called once at startup after startupSweep, so in-flight
+ * keyboard sessions survive a server restart.
+ *
+ * On timeout fire: edits the ack message to "Timed out — using default (medium)"
+ * and continues narration with default length via the provided continueNarration callback.
+ *
+ * pendingTimeouts is the module-scoped map in narrator.ts; we write into it so
+ * the callback handler can clearTimeout if the user taps before expiry.
+ */
+export function rebuildPendingTimeouts(
+  db: Database.Database,
+  api: Api,
+  me: UserFromGetMe,
+  onTimeout: (jobId: string, length: 'short' | 'medium' | 'full', ctx: Context) => Promise<void>,
+): void {
+  const now = Date.now();
+  const rows = db.prepare(
+    "SELECT job_id, chat_id, keyboard_msg_id, source_tmpfile, expires_at FROM pending_length_choices WHERE expires_at >= ?"
+  ).all(now) as PendingRow[];
+
+  for (const row of rows) {
+    const delay = Math.max(0, row.expires_at - Date.now());
+
+    const handle = setTimeout(async () => {
+      // Atomically consume — avoid double-fire with normal callback path
+      const still = db.prepare(`DELETE FROM pending_length_choices WHERE job_id = ? RETURNING *`).get(row.job_id);
+      pendingTimeouts.delete(row.job_id);
+      if (!still) return; // already handled by callback
+
+      const { job_id: jobId, chat_id: chatId, keyboard_msg_id: ackMessageId } = row;
+
+      // Edit ack message to indicate timeout
+      if (ackMessageId) {
+        try {
+          await api.editMessageText(chatId, ackMessageId, 'Timed out — using default (medium)');
+        } catch { /* swallow — message may be gone */ }
+      }
+
+      // Look up userId from jobs table (needed to construct synthetic Context)
+      const jobRow = db.prepare(`SELECT user_id FROM jobs WHERE id = ?`).get(jobId) as JobRow | undefined;
+      if (!jobRow) {
+        console.warn(`rebuildPendingTimeouts: no job row for ${jobId} — cannot continue narration`);
+        try { await fs.unlink(row.source_tmpfile); } catch { /* gone */ }
+        return;
+      }
+
+      // Build a synthetic Update so continueNarration gets a proper Context
+      const syntheticUpdate: Update = {
+        update_id: 0,
+        message: {
+          message_id: 0,
+          date: Math.floor(Date.now() / 1000),
+          chat: { id: chatId, type: 'private' },
+          from: {
+            id: jobRow.user_id,
+            is_bot: false,
+            first_name: '',
+          },
+        } as Update['message'],
+      };
+
+      const ctx = new Context(syntheticUpdate, api, me);
+      await onTimeout(jobId, 'medium', ctx);
+    }, delay);
+
+    pendingTimeouts.set(row.job_id, handle);
+    console.log(`startup: rebuilt timeout for pending choice ${row.job_id} (fires in ${Math.round(delay / 1000)}s)`);
+  }
 }


### PR DESCRIPTION
Closes #35

## What changed

**`startupSweep` orphan fix**
The sweep that marks active jobs failed now excludes jobs with a live `pending_length_choice` (i.e., still within their expiry window). Previously all active jobs were marked failed on restart, which would cause the rebuilt timeouts to silently skip narration (the `status = 'active'` guard in `continueNarration` would reject them).

**`rebuildPendingTimeouts`** (new export from `state/cleanup.ts`)
Queries `pending_length_choices WHERE expires_at >= now`, and for each row sets a `setTimeout` with the remaining delay. On fire:
1. Atomically deletes the row (RETURNING guard prevents double-fire)
2. Edits the ack message: "Timed out — using default (medium)"
3. Constructs a synthetic grammY `Context` via `new Context(syntheticUpdate, api, me)` and calls `continueNarration`

**`pendingTimeouts` exported** from `handlers/narrator.ts`
The rebuilt handles are registered into the same map so the callback handler can `clearTimeout` if the user taps before expiry.

**`index.ts`**
Calls `bot.api.getMe()` + `rebuildPendingTimeouts(...)` between `startupSweep` and `bot.start()`.

## Test plan
- [ ] All 60 existing tests pass (`npm test`)
- [ ] `tsc` clean
- [ ] Manual: send text, don't tap keyboard, restart server within timeout window → "Timed out — using default (medium)" edits, narration completes
- [ ] Manual: send text, tap keyboard before restart fires timeout → narration completes normally (no duplicate)