### PR TITLE
feat(narrator): Phase 6 — idea_dobot migration + CPC deep-link (#43)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,12 @@ export const config = {
   telegramNarratorBotToken: required('TELEGRAM_NARRATOR_BOT_TOKEN'),
   telegramIdeaBotToken: process.env['TELEGRAM_IDEA_BOT_TOKEN'],
   dobotDbPath: optional('DOBOT_DB_PATH', '/home/claude/.local/share/dobot-server/state.db'),
+  ideaCapture: {
+    allowedUserIds: new Set(
+      optional('IDEA_ALLOWED_USER_IDS', '').split(',').filter(Boolean).map(Number)
+    ),
+    ideaFile: optional('IDEA_FILE', '/home/claude/ideas.md'),
+  },
   narrator: {
     allowedUserIds: new Set(
       optional('NARRATOR_ALLOWED_USER_IDS', '').split(',').filter(Boolean).map(Number)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -22,6 +23,7 @@ export const config = {
       optional('IDEA_ALLOWED_USER_IDS', '').split(',').filter(Boolean).map(Number)
     ),
     ideaFile: optional('IDEA_FILE', '/home/claude/ideas.md'),
+    photosDir: path.resolve(process.env['IDEA_PHOTOS_DIR'] ?? path.join(os.homedir(), 'ideas-photos')),
   },
   narrator: {
     allowedUserIds: new Set(

--- a/src/delivery/narrator.ts
+++ b/src/delivery/narrator.ts
@@ -8,6 +8,10 @@ import { config } from '../config.js';
 import { buildSubprocessEnv } from '../lib/claude-subprocess.js';
 import { recordSpend } from '../lib/rate-limit.js';
 
+function toBase64url(s: string): string {
+  return Buffer.from(s).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
 export interface DeliveryOptions {
   jobId: string;
   userId: number;
@@ -54,7 +58,7 @@ export async function deliverNarration(opts: DeliveryOptions): Promise<void> {
   await fs.writeFile(mdPath, finalNarrative);
 
   // 2. Construct CPC deep link directly from mdPath
-  const deepLink: string = `https://t.me/claude_do_bot/pocket?startapp=${encodeURIComponent(mdPath)}`;
+  const deepLink: string = `https://t.me/claude_do_bot/pocket?startapp=${toBase64url(mdPath)}`;
 
   // 3. Invoke md-speak --no-describe to generate audio
   const mp3Path = mdPath.replace(/\.md$/, '.mp3');

--- a/src/delivery/narrator.ts
+++ b/src/delivery/narrator.ts
@@ -7,10 +7,7 @@ import Database from 'better-sqlite3';
 import { config } from '../config.js';
 import { buildSubprocessEnv } from '../lib/claude-subprocess.js';
 import { recordSpend } from '../lib/rate-limit.js';
-
-function toBase64url(s: string): string {
-  return Buffer.from(s).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
+import { toBase64url } from '../lib/telegram.js';
 
 export interface DeliveryOptions {
   jobId: string;
@@ -131,8 +128,9 @@ export async function deliverNarration(opts: DeliveryOptions): Promise<void> {
         if (!shareUrl) {
           throw new Error('publish-shared did not output a URL line');
         }
-        const urlKeyboard = new InlineKeyboard().url('Download audio', shareUrl);
-        urlKeyboard.url('Read in Pocket Console', deepLink);
+        const urlKeyboard = new InlineKeyboard()
+          .url('Download audio', shareUrl).row()
+          .url('Read in Pocket Console', deepLink);
         await ctx.reply(caption, { reply_markup: urlKeyboard });
       } catch (pubErr) {
         console.error('narrator: publish-shared failed:', pubErr);

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -5,10 +5,7 @@ import os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { execa } from 'execa';
 import { config } from '../config.js';
-
-function toBase64url(s: string): string {
-  return Buffer.from(s).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
+import { toBase64url } from '../lib/telegram.js';
 
 /** Format the "from" field: "Display Name (@username)" or just "Display Name". */
 function formatFrom(ctx: Context): string {
@@ -43,13 +40,13 @@ function isoTimestampET(date: Date): string {
 }
 
 /** Download a Telegram file by file_id and save to destPath. */
-async function downloadTelegramFile(bot: Bot, fileId: string, destPath: string): Promise<void> {
+async function downloadTelegramFile(bot: Bot, fileId: string, destPath: string, signal?: AbortSignal): Promise<void> {
   const file = await bot.api.getFile(fileId);
   if (!file.file_path) {
     throw new Error(`Telegram returned no file_path for file_id ${fileId}`);
   }
   const url = `https://api.telegram.org/file/bot${bot.token}/${file.file_path}`;
-  const resp = await fetch(url);
+  const resp = await fetch(url, { signal });
   if (!resp.ok) {
     throw new Error(`Failed to download file: ${resp.status} ${resp.statusText}`);
   }
@@ -63,9 +60,11 @@ async function appendIdea(opts: {
   from: string;
   timestamp: string;
   body: string;
+  photoPath?: string;
 }): Promise<void> {
-  const { type, from, timestamp, body } = opts;
-  const entry = `---\n## ${type} idea — ${timestamp}\n**From:** ${from}\n\n${body}\n\n`;
+  const { type, from, timestamp, body, photoPath } = opts;
+  const photoLine = photoPath ? `![photo](${photoPath}) ` : '';
+  const entry = `---\n## ${type} idea — ${timestamp}\n**From:** ${from}\n\n${photoLine}${body}\n\n`;
   await fs.appendFile(config.ideaCapture.ideaFile, entry, 'utf8');
 }
 
@@ -114,7 +113,13 @@ export function createIdeaCaptureHandler(bot: Bot) {
     if (voice) {
       const tempPath = path.join(os.tmpdir(), `idea-voice-${randomUUID()}.oga`);
       try {
-        await downloadTelegramFile(bot, voice.file_id, tempPath);
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 30_000);
+        try {
+          await downloadTelegramFile(bot, voice.file_id, tempPath, controller.signal);
+        } finally {
+          clearTimeout(timer);
+        }
 
         const result = await execa('/home/claude/bin/transcribe', [tempPath], {
           timeout: 60000,
@@ -143,19 +148,25 @@ export function createIdeaCaptureHandler(bot: Bot) {
     if (photos && photos.length > 0) {
       // Telegram sends photos sorted by size — take the largest
       const largest = photos[photos.length - 1];
-      const tempPath = path.join(os.tmpdir(), `idea-photo-${randomUUID()}.jpg`);
+      const permanentPath = path.join(config.ideaCapture.photosDir, `idea-photo-${randomUUID()}.jpg`);
       try {
-        await downloadTelegramFile(bot, largest.file_id, tempPath);
+        await fs.mkdir(config.ideaCapture.photosDir, { recursive: true });
 
-        const caption = ctx.message?.caption ?? '[photo]';
-        await appendIdea({ type: 'photo', from, timestamp, body: caption });
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 30_000);
+        try {
+          await downloadTelegramFile(bot, largest.file_id, permanentPath, controller.signal);
+        } finally {
+          clearTimeout(timer);
+        }
+
+        const caption = ctx.message?.caption ?? '';
+        await appendIdea({ type: 'photo', from, timestamp, body: caption, photoPath: permanentPath });
         await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[idea-capture/photo] Error:', msg);
         await ctx.reply(`Photo processing failed: ${msg}`).catch(() => {});
-      } finally {
-        try { await fs.unlink(tempPath); } catch { /* may not exist */ }
       }
       return;
     }

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -1,0 +1,155 @@
+import { Context, InlineKeyboard, Bot } from 'grammy';
+import fs from 'node:fs/promises';
+import { execa } from 'execa';
+import { config } from '../config.js';
+
+/** Format the "from" field: "Display Name (@username)" or just "Display Name". */
+function formatFrom(ctx: Context): string {
+  const user = ctx.from;
+  if (!user) return 'unknown';
+  const name = [user.first_name, user.last_name].filter(Boolean).join(' ');
+  return user.username ? `${name} (@${user.username})` : name;
+}
+
+/** Get ISO8601 timestamp in Eastern Time. */
+function isoTimestampET(date: Date): string {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(date).map(p => [p.type, p.value]));
+  // Determine ET offset (EDT = -04:00, EST = -05:00)
+  const tzFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    timeZoneName: 'short',
+  });
+  const tzParts = tzFmt.formatToParts(date);
+  const tzName = tzParts.find(p => p.type === 'timeZoneName')?.value;
+  const offset = tzName === 'EDT' ? '-04:00' : '-05:00';
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}${offset}`;
+}
+
+/** Download a Telegram file by file_id and save to destPath. */
+async function downloadTelegramFile(bot: Bot, fileId: string, destPath: string): Promise<void> {
+  const file = await bot.api.getFile(fileId);
+  if (!file.file_path) {
+    throw new Error(`Telegram returned no file_path for file_id ${fileId}`);
+  }
+  const url = `https://api.telegram.org/file/bot${bot.token}/${file.file_path}`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`Failed to download file: ${resp.status} ${resp.statusText}`);
+  }
+  const buf = Buffer.from(await resp.arrayBuffer());
+  await fs.writeFile(destPath, buf);
+}
+
+/** Append an idea entry to the idea file. */
+async function appendIdea(opts: {
+  type: 'text' | 'voice' | 'photo';
+  from: string;
+  timestamp: string;
+  body: string;
+}): Promise<void> {
+  const { type, from, timestamp, body } = opts;
+  const entry = `---\n## ${type} idea — ${timestamp}\n**From:** ${from}\n\n${body}\n\n`;
+  await fs.appendFile(config.ideaCapture.ideaFile, entry, 'utf8');
+}
+
+/** Build the CPC t.me deep-link button for the idea file. */
+function buildIdeaKeyboard(): InlineKeyboard {
+  const deepLink = `https://t.me/claude_do_bot/pocket?startapp=${encodeURIComponent(config.ideaCapture.ideaFile)}`;
+  return new InlineKeyboard().url('View in Pocket', deepLink);
+}
+
+/**
+ * Factory — returns a grammY message handler for idea capture.
+ * Handles text, voice, and photo messages.
+ */
+export function createIdeaCaptureHandler(bot: Bot) {
+  return async function ideaCaptureHandler(ctx: Context): Promise<void> {
+    // DM-only
+    if (ctx.chat?.type !== 'private') return;
+
+    const userId = ctx.from?.id;
+    if (!userId) return;
+
+    // Access guard — silently reject if not in allowlist
+    if (!config.ideaCapture.allowedUserIds.has(userId)) return;
+
+    const from = formatFrom(ctx);
+    const now = new Date();
+    const timestamp = isoTimestampET(now);
+    const keyboard = buildIdeaKeyboard();
+
+    // --- Text message ---
+    const text = ctx.message?.text;
+    if (text) {
+      try {
+        await appendIdea({ type: 'text', from, timestamp, body: text });
+        await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[idea-capture/text] Error:', msg);
+        await ctx.reply(`Failed to save idea: ${msg}`);
+      }
+      return;
+    }
+
+    // --- Voice message ---
+    const voice = ctx.message?.voice;
+    if (voice) {
+      const tempPath = `/tmp/dobot-voice-${Date.now()}.oga`;
+      try {
+        await downloadTelegramFile(bot, voice.file_id, tempPath);
+
+        const result = await execa('/home/claude/bin/transcribe', [tempPath], {
+          timeout: 60000,
+        });
+        const transcribed = result.stdout.trim();
+
+        if (!transcribed) {
+          await ctx.reply('Could not transcribe voice note (empty result)');
+          return;
+        }
+
+        await appendIdea({ type: 'voice', from, timestamp, body: transcribed });
+        await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[idea-capture/voice] Error:', msg);
+        await ctx.reply(`Voice transcription failed: ${msg}`);
+      } finally {
+        try { await fs.unlink(tempPath); } catch { /* temp file may not exist */ }
+      }
+      return;
+    }
+
+    // --- Photo message ---
+    const photos = ctx.message?.photo;
+    if (photos && photos.length > 0) {
+      // Telegram sends photos sorted by size — take the largest
+      const largest = photos[photos.length - 1];
+      const tempPath = `/tmp/dobot-photo-${Date.now()}.jpg`;
+      try {
+        await downloadTelegramFile(bot, largest.file_id, tempPath);
+
+        const caption = ctx.message?.caption ?? '[photo]';
+        await appendIdea({ type: 'photo', from, timestamp, body: caption });
+        await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[idea-capture/photo] Error:', msg);
+        try { await fs.unlink(tempPath); } catch { /* may not exist */ }
+        await ctx.reply(`Photo processing failed: ${msg}`);
+      }
+      return;
+    }
+  };
+}

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -41,7 +41,12 @@ function isoTimestampET(date: Date): string {
 
 /** Download a Telegram file by file_id and save to destPath. */
 async function downloadTelegramFile(bot: Bot, fileId: string, destPath: string, signal?: AbortSignal): Promise<void> {
-  const file = await bot.api.getFile(fileId);
+  const file = await Promise.race([
+    bot.api.getFile(fileId),
+    new Promise<never>((_, reject) =>
+      signal?.addEventListener('abort', () => reject(new Error('getFile timeout')))
+    ),
+  ]);
   if (!file.file_path) {
     throw new Error(`Telegram returned no file_path for file_id ${fileId}`);
   }
@@ -161,12 +166,14 @@ export function createIdeaCaptureHandler(bot: Bot) {
         }
 
         const caption = ctx.message?.caption ?? '';
-        await appendIdea({ type: 'photo', from, timestamp, body: caption, photoPath: permanentPath });
+        const relPath = path.relative(os.homedir(), permanentPath);
+        await appendIdea({ type: 'photo', from, timestamp, body: caption, photoPath: relPath });
         await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[idea-capture/photo] Error:', msg);
-        await ctx.reply(`Photo processing failed: ${msg}`).catch(() => {});
+        try { await fs.unlink(permanentPath); } catch { }
+        await ctx.reply('⚠️ Failed to save photo').catch(() => {});
       }
       return;
     }

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -154,6 +154,7 @@ export function createIdeaCaptureHandler(bot: Bot) {
       // Telegram sends photos sorted by size — take the largest
       const largest = photos[photos.length - 1];
       const permanentPath = path.join(config.ideaCapture.photosDir, `idea-photo-${randomUUID()}.jpg`);
+      let recorded = false;
       try {
         await fs.mkdir(config.ideaCapture.photosDir, { recursive: true });
 
@@ -166,13 +167,17 @@ export function createIdeaCaptureHandler(bot: Bot) {
         }
 
         const caption = ctx.message?.caption ?? '';
-        const relPath = path.relative(os.homedir(), permanentPath);
+        const relPath = path.relative(path.dirname(config.ideaCapture.ideaFile), permanentPath);
         await appendIdea({ type: 'photo', from, timestamp, body: caption, photoPath: relPath });
+        recorded = true;  // file is now referenced in the idea entry
         await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[idea-capture/photo] Error:', msg);
-        try { await fs.unlink(permanentPath); } catch { }
+        if (!recorded) {
+          // Only clean up if the entry was never committed
+          try { await fs.unlink(permanentPath); } catch { }
+        }
         await ctx.reply('⚠️ Failed to save photo').catch(() => {});
       }
       return;

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -1,7 +1,14 @@
 import { Context, InlineKeyboard, Bot } from 'grammy';
 import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
 import { execa } from 'execa';
 import { config } from '../config.js';
+
+function toBase64url(s: string): string {
+  return Buffer.from(s).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
 
 /** Format the "from" field: "Display Name (@username)" or just "Display Name". */
 function formatFrom(ctx: Context): string {
@@ -64,7 +71,7 @@ async function appendIdea(opts: {
 
 /** Build the CPC t.me deep-link button for the idea file. */
 function buildIdeaKeyboard(): InlineKeyboard {
-  const deepLink = `https://t.me/claude_do_bot/pocket?startapp=${encodeURIComponent(config.ideaCapture.ideaFile)}`;
+  const deepLink = `https://t.me/claude_do_bot/pocket?startapp=${toBase64url(config.ideaCapture.ideaFile)}`;
   return new InlineKeyboard().url('View in Pocket', deepLink);
 }
 
@@ -105,7 +112,7 @@ export function createIdeaCaptureHandler(bot: Bot) {
     // --- Voice message ---
     const voice = ctx.message?.voice;
     if (voice) {
-      const tempPath = `/tmp/dobot-voice-${Date.now()}.oga`;
+      const tempPath = path.join(os.tmpdir(), `idea-voice-${randomUUID()}.oga`);
       try {
         await downloadTelegramFile(bot, voice.file_id, tempPath);
 
@@ -136,7 +143,7 @@ export function createIdeaCaptureHandler(bot: Bot) {
     if (photos && photos.length > 0) {
       // Telegram sends photos sorted by size — take the largest
       const largest = photos[photos.length - 1];
-      const tempPath = `/tmp/dobot-photo-${Date.now()}.jpg`;
+      const tempPath = path.join(os.tmpdir(), `idea-photo-${randomUUID()}.jpg`);
       try {
         await downloadTelegramFile(bot, largest.file_id, tempPath);
 
@@ -146,8 +153,9 @@ export function createIdeaCaptureHandler(bot: Bot) {
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[idea-capture/photo] Error:', msg);
+        await ctx.reply(`Photo processing failed: ${msg}`).catch(() => {});
+      } finally {
         try { await fs.unlink(tempPath); } catch { /* may not exist */ }
-        await ctx.reply(`Photo processing failed: ${msg}`);
       }
       return;
     }

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -43,9 +43,13 @@ function isoTimestampET(date: Date): string {
 async function downloadTelegramFile(bot: Bot, fileId: string, destPath: string, signal?: AbortSignal): Promise<void> {
   const file = await Promise.race([
     bot.api.getFile(fileId),
-    new Promise<never>((_, reject) =>
-      signal?.addEventListener('abort', () => reject(new Error('getFile timeout')))
-    ),
+    new Promise<never>((_, reject) => {
+      if (signal?.aborted) {
+        reject(new Error('getFile timeout'));
+        return;
+      }
+      signal?.addEventListener('abort', () => reject(new Error('getFile timeout')), { once: true });
+    }),
   ]);
   if (!file.file_path) {
     throw new Error(`Telegram returned no file_path for file_id ${fileId}`);

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -65,6 +65,7 @@ function userFacingError(err: unknown): string {
 
 export function createNarratorHandler(db: Database.Database) {
   return async function narratorHandler(ctx: Context): Promise<void> {
+    // DM-only — silently reject group/supergroup/channel messages (#47)
     if (ctx.chat?.type !== 'private') return;
 
     const userId = ctx.from?.id;
@@ -72,9 +73,6 @@ export function createNarratorHandler(db: Database.Database) {
 
     // 1. Filter — silently reject if not in allowlist
     if (!config.narrator.allowedUserIds.has(userId)) return;
-
-    // 2. DM-only — silently reject group/supergroup/channel messages (#47)
-    if (ctx.chat?.type !== "private") return;
 
     // 1a. Forwarded message detection — check before plain text extraction
     // Note: forward_origin is the canonical forwarded-message indicator in Bot API 7.x+.
@@ -182,6 +180,7 @@ export function createNarratorHandler(db: Database.Database) {
     const wordCount = sourceText.split(/\s+/).filter(Boolean).length;
     if (wordCount > config.narrator.maxSourceWords) {
       console.log(`narrator: rejected oversized input (${wordCount} words) from user ${userId}`);
+      await ctx.reply('Your source text is too long. Please trim it to under the word limit and try again.');
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import './lib/otel.js';
 import 'dotenv/config';
+import { Bot } from 'grammy';
 import { config } from './config.js';
 import { createBot } from './bot-factory.js';
 import { openDatabase } from './state/db.js';
@@ -7,6 +8,7 @@ import { startupSweep, rebuildPendingTimeouts } from './state/cleanup.js';
 import { registerHandlers } from './router.js';
 import { createNarratorHandler, continueNarration, createCancelHandler } from './handlers/narrator.js';
 import { createLengthCallbackHandler } from './handlers/narrator-callback.js';
+import { createIdeaCaptureHandler } from './handlers/idea-capture.js';
 
 async function main(): Promise<void> {
   const db = openDatabase(config.dobotDbPath);
@@ -28,6 +30,17 @@ async function main(): Promise<void> {
     cancel: createCancelHandler(db),
   });
 
+  // Wire idea capture bot if token is configured
+  let ideaBot: Bot | undefined;
+  const ideaBotToken = config.telegramIdeaBotToken;
+  if (ideaBotToken) {
+    ideaBot = createBot(ideaBotToken);
+    ideaBot.on('message', createIdeaCaptureHandler(ideaBot));
+    console.log('dobot-server: idea capture bot enabled');
+  } else {
+    console.warn('dobot-server: TELEGRAM_IDEA_BOT_TOKEN not set — idea capture bot disabled');
+  }
+
   // Graceful shutdown — idempotent guard ensures concurrent SIGINT+SIGTERM
   // (e.g. double Ctrl+C) only runs stop/close once.
   let shutdownPromise: Promise<void> | null = null;
@@ -36,6 +49,7 @@ async function main(): Promise<void> {
     if (shutdownPromise) return shutdownPromise;
     shutdownPromise = (async () => {
       await narratorBot.stop();
+      if (ideaBot) await ideaBot.stop();
       db.close();
     })();
     return shutdownPromise;
@@ -44,7 +58,9 @@ async function main(): Promise<void> {
   process.once('SIGTERM', () => { shutdown().catch(console.error); });
 
   console.log('dobot-server listening...');
-  await narratorBot.start();
+  const botPromises: Promise<void>[] = [narratorBot.start()];
+  if (ideaBot) botPromises.push(ideaBot.start());
+  await Promise.all(botPromises);
 }
 
 main().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,9 @@ async function main(): Promise<void> {
   if (ideaBotToken) {
     ideaBot = createBot(ideaBotToken);
     ideaBot.on('message', createIdeaCaptureHandler(ideaBot));
+    if (config.ideaCapture.allowedUserIds.size === 0) {
+      console.warn('dobot-server: IDEA_ALLOWED_USER_IDS is not set — idea bot will reject all messages');
+    }
     console.log('dobot-server: idea capture bot enabled');
   } else {
     console.warn('dobot-server: TELEGRAM_IDEA_BOT_TOKEN not set — idea capture bot disabled');
@@ -58,9 +61,13 @@ async function main(): Promise<void> {
   process.once('SIGTERM', () => { shutdown().catch(console.error); });
 
   console.log('dobot-server listening...');
-  const botPromises: Promise<void>[] = [narratorBot.start()];
-  if (ideaBot) botPromises.push(ideaBot.start());
-  await Promise.all(botPromises);
+  try {
+    await Promise.all([narratorBot.start(), ...(ideaBot ? [ideaBot.start()] : [])]);
+  } catch (err) {
+    console.error('Bot startup failed — shutting down', err);
+    await shutdown();
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,9 @@ async function main(): Promise<void> {
   if (ideaBotToken) {
     ideaBot = createBot(ideaBotToken);
     ideaBot.on('message', createIdeaCaptureHandler(ideaBot));
+    ideaBot.catch((err) => {
+      console.error('ideaBot: unhandled error in handler', err);
+    });
     if (config.ideaCapture.allowedUserIds.size === 0) {
       console.warn('dobot-server: IDEA_ALLOWED_USER_IDS is not set — idea bot will reject all messages');
     }

--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -1,0 +1,4 @@
+/** Base64url-encode a string for use as a Telegram Mini App `startapp` parameter. */
+export function toBase64url(s: string): string {
+  return Buffer.from(s).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}

--- a/test/handlers/idea-capture.test.ts
+++ b/test/handlers/idea-capture.test.ts
@@ -167,7 +167,7 @@ describe('ideaCaptureHandler — voice messages', () => {
     expect(execaMock).toHaveBeenCalledOnce();
     const [bin, args] = execaMock.mock.calls[0] as [string, string[]];
     expect(bin).toBe('/home/claude/bin/transcribe');
-    expect(args[0]).toMatch(/^\/tmp\/dobot-voice-\d+\.oga$/);
+    expect(args[0]).toMatch(/idea-voice-[0-9a-f-]+\.oga$/);
 
     // appendFile called with transcribed content
     expect(appendSpy).toHaveBeenCalledOnce();
@@ -199,6 +199,60 @@ describe('ideaCaptureHandler — voice messages', () => {
 
     expect(unlinkSpy).toHaveBeenCalledOnce();
     const unlinkedPath = unlinkSpy.mock.calls[0][0] as string;
-    expect(unlinkedPath).toMatch(/^\/tmp\/dobot-voice-\d+\.oga$/);
+    expect(unlinkedPath).toMatch(/idea-voice-[0-9a-f-]+\.oga$/);
+  });
+});
+
+describe('ideaCaptureHandler — photo messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch();
+  });
+
+  it('7. Photo temp file deleted after successful save', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const unlinkSpy = vi.mocked(fsMock.unlink);
+
+    const bot = makeBot();
+    const ctx = makeCtx({
+      message: {
+        message_id: 42,
+        caption: 'cool idea',
+        photo: [
+          { file_id: 'photo-small', width: 100, height: 100 },
+          { file_id: 'photo-large', width: 800, height: 600 },
+        ],
+      },
+    });
+
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    expect(unlinkSpy).toHaveBeenCalledOnce();
+    const unlinkedPath = unlinkSpy.mock.calls[0][0] as string;
+    expect(unlinkedPath).toMatch(/idea-photo-[0-9a-f-]+\.jpg$/);
+  });
+
+  it('8. Photo temp file deleted even when appendFile fails', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const appendSpy = vi.mocked(fsMock.appendFile);
+    const unlinkSpy = vi.mocked(fsMock.unlink);
+
+    appendSpy.mockRejectedValueOnce(new Error('disk full'));
+
+    const bot = makeBot();
+    const ctx = makeCtx({
+      message: {
+        message_id: 42,
+        photo: [{ file_id: 'photo-large', width: 800, height: 600 }],
+      },
+    });
+
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    expect(unlinkSpy).toHaveBeenCalledOnce();
+    const unlinkedPath = unlinkSpy.mock.calls[0][0] as string;
+    expect(unlinkedPath).toMatch(/idea-photo-[0-9a-f-]+\.jpg$/);
   });
 });

--- a/test/handlers/idea-capture.test.ts
+++ b/test/handlers/idea-capture.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../src/config.js', () => ({
     ideaCapture: {
       allowedUserIds: new Set([1]),
       ideaFile: '/tmp/test-ideas.md',
+      photosDir: '/tmp/ideas-photos',
     },
     narrator: {
       allowedUserIds: new Set([1]),
@@ -209,8 +210,9 @@ describe('ideaCaptureHandler — photo messages', () => {
     mockFetch();
   });
 
-  it('7. Photo temp file deleted after successful save', async () => {
+  it('7. Photo saved to permanent path (no temp file)', async () => {
     const { default: fsMock } = await import('node:fs/promises');
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
     const unlinkSpy = vi.mocked(fsMock.unlink);
 
     const bot = makeBot();
@@ -228,12 +230,13 @@ describe('ideaCaptureHandler — photo messages', () => {
     const handler = createIdeaCaptureHandler(bot as never);
     await handler(ctx as never);
 
-    expect(unlinkSpy).toHaveBeenCalledOnce();
-    const unlinkedPath = unlinkSpy.mock.calls[0][0] as string;
-    expect(unlinkedPath).toMatch(/idea-photo-[0-9a-f-]+\.jpg$/);
+    // Photo written directly to permanent path — no unlink
+    expect(unlinkSpy).not.toHaveBeenCalled();
+    const writtenPath = writeFileSpy.mock.calls[0][0] as string;
+    expect(writtenPath).toMatch(/\/tmp\/ideas-photos\/idea-photo-[0-9a-f-]+\.jpg$/);
   });
 
-  it('8. Photo temp file deleted even when appendFile fails', async () => {
+  it('8. Photo error reply sent when appendFile fails (no unlink)', async () => {
     const { default: fsMock } = await import('node:fs/promises');
     const appendSpy = vi.mocked(fsMock.appendFile);
     const unlinkSpy = vi.mocked(fsMock.unlink);
@@ -251,8 +254,10 @@ describe('ideaCaptureHandler — photo messages', () => {
     const handler = createIdeaCaptureHandler(bot as never);
     await handler(ctx as never);
 
-    expect(unlinkSpy).toHaveBeenCalledOnce();
-    const unlinkedPath = unlinkSpy.mock.calls[0][0] as string;
-    expect(unlinkedPath).toMatch(/idea-photo-[0-9a-f-]+\.jpg$/);
+    // No temp file to unlink — error reply sent instead
+    expect(unlinkSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(ctx.reply)).toHaveBeenCalledWith(
+      expect.stringMatching(/Photo processing failed/),
+    );
   });
 });

--- a/test/handlers/idea-capture.test.ts
+++ b/test/handlers/idea-capture.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock config FIRST — before any imports that pull in config.ts
+vi.mock('../../src/config.js', () => ({
+  config: {
+    telegramNarratorBotToken: 'test-narrator-token',
+    telegramIdeaBotToken: 'test-idea-token',
+    ideaCapture: {
+      allowedUserIds: new Set([1]),
+      ideaFile: '/tmp/test-ideas.md',
+    },
+    narrator: {
+      allowedUserIds: new Set([1]),
+      agentRunScript: '/fake/run.sh',
+      narratorRoot: '/fake/claudes-world/agents/narrator',
+      classifyModel: 'claude-haiku-4-5',
+      rewriteModel: 'claude-sonnet-4-6',
+      claudeTimeout: 30000,
+      mdSpeakTimeout: 30000,
+      maxSourceWords: 8000,
+      storiesDir: '/tmp/stories',
+      tmpDir: '/tmp',
+      maxJobsPerHour: 10,
+      maxDailyTtsUsd: 5.0,
+      lengthTimeoutMs: 20000,
+    },
+  },
+}));
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    appendFile: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+  },
+  appendFile: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('execa', () => ({
+  execa: vi.fn().mockResolvedValue({ stdout: 'transcribed text from voice note', stderr: '' }),
+}));
+
+import { execa } from 'execa';
+import { createIdeaCaptureHandler } from '../../src/handlers/idea-capture.js';
+
+function makeBot(overrides: Record<string, unknown> = {}) {
+  return {
+    token: 'test-token',
+    api: {
+      getFile: vi.fn().mockResolvedValue({ file_path: 'voice/file.oga' }),
+    },
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    from: { id: 1, first_name: 'Liam', last_name: undefined, username: 'liamtest' },
+    chat: { id: 100, type: 'private' },
+    message: { text: 'This is my idea text', message_id: 42 },
+    reply: vi.fn().mockResolvedValue({ message_id: 99 }),
+    ...overrides,
+  };
+}
+
+// Patch global fetch for download tests
+function mockFetch(ok = true) {
+  const mockArrayBuffer = new ArrayBuffer(8);
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 404,
+    statusText: ok ? 'OK' : 'Not Found',
+    arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+  }) as unknown as typeof fetch;
+}
+
+describe('ideaCaptureHandler — text messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch();
+  });
+
+  it('1. Text message saved — appendFile called with idea content', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const appendSpy = vi.mocked(fsMock.appendFile);
+
+    const bot = makeBot();
+    const ctx = makeCtx();
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    expect(appendSpy).toHaveBeenCalledOnce();
+    const [filePath, content] = appendSpy.mock.calls[0] as [string, string];
+    expect(filePath).toBe('/tmp/test-ideas.md');
+    expect(content).toContain('This is my idea text');
+    expect(content).toContain('text idea');
+    expect(content).toContain('Liam (@liamtest)');
+  });
+
+  it('2. Text message saved — bot replies with ✅ Idea saved', async () => {
+    const bot = makeBot();
+    const ctx = makeCtx();
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    expect(ctx.reply).toHaveBeenCalledOnce();
+    expect(ctx.reply).toHaveBeenCalledWith(
+      '✅ Idea saved',
+      expect.objectContaining({ reply_markup: expect.anything() })
+    );
+  });
+
+  it('3. Unknown user rejected — no appendFile, no reply', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const appendSpy = vi.mocked(fsMock.appendFile);
+
+    const bot = makeBot();
+    const ctx = makeCtx({ from: { id: 999, first_name: 'Stranger' } });
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    expect(appendSpy).not.toHaveBeenCalled();
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+
+  it('4. Group message rejected — DM-only filter', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const appendSpy = vi.mocked(fsMock.appendFile);
+
+    const bot = makeBot();
+    const ctx = makeCtx({ chat: { id: -100, type: 'supergroup' } });
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    expect(appendSpy).not.toHaveBeenCalled();
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+});
+
+describe('ideaCaptureHandler — voice messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch();
+  });
+
+  it('5. Voice message transcribed and saved', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const appendSpy = vi.mocked(fsMock.appendFile);
+    const execaMock = vi.mocked(execa);
+
+    const bot = makeBot();
+    const ctx = makeCtx({
+      message: {
+        message_id: 42,
+        voice: { file_id: 'voice-file-id-123', duration: 5 },
+      },
+    });
+
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    // execa called with transcribe binary and a temp path
+    expect(execaMock).toHaveBeenCalledOnce();
+    const [bin, args] = execaMock.mock.calls[0] as [string, string[]];
+    expect(bin).toBe('/home/claude/bin/transcribe');
+    expect(args[0]).toMatch(/^\/tmp\/dobot-voice-\d+\.oga$/);
+
+    // appendFile called with transcribed content
+    expect(appendSpy).toHaveBeenCalledOnce();
+    const [, content] = appendSpy.mock.calls[0] as [string, string];
+    expect(content).toContain('transcribed text from voice note');
+    expect(content).toContain('voice idea');
+
+    // Reply sent
+    expect(ctx.reply).toHaveBeenCalledWith(
+      '✅ Idea saved',
+      expect.objectContaining({ reply_markup: expect.anything() })
+    );
+  });
+
+  it('6. Voice temp file cleaned up after transcription', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const unlinkSpy = vi.mocked(fsMock.unlink);
+
+    const bot = makeBot();
+    const ctx = makeCtx({
+      message: {
+        message_id: 42,
+        voice: { file_id: 'voice-file-id-456', duration: 3 },
+      },
+    });
+
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never);
+
+    expect(unlinkSpy).toHaveBeenCalledOnce();
+    const unlinkedPath = unlinkSpy.mock.calls[0][0] as string;
+    expect(unlinkedPath).toMatch(/^\/tmp\/dobot-voice-\d+\.oga$/);
+  });
+});

--- a/test/handlers/idea-capture.test.ts
+++ b/test/handlers/idea-capture.test.ts
@@ -236,7 +236,7 @@ describe('ideaCaptureHandler — photo messages', () => {
     expect(writtenPath).toMatch(/\/tmp\/ideas-photos\/idea-photo-[0-9a-f-]+\.jpg$/);
   });
 
-  it('8. Photo error reply sent when appendFile fails (no unlink)', async () => {
+  it('8. Photo error reply sent and orphan cleaned up when appendFile fails', async () => {
     const { default: fsMock } = await import('node:fs/promises');
     const appendSpy = vi.mocked(fsMock.appendFile);
     const unlinkSpy = vi.mocked(fsMock.unlink);
@@ -254,10 +254,10 @@ describe('ideaCaptureHandler — photo messages', () => {
     const handler = createIdeaCaptureHandler(bot as never);
     await handler(ctx as never);
 
-    // No temp file to unlink — error reply sent instead
-    expect(unlinkSpy).not.toHaveBeenCalled();
+    // Orphaned permanent photo file should be cleaned up on error
+    expect(unlinkSpy).toHaveBeenCalledOnce();
     expect(vi.mocked(ctx.reply)).toHaveBeenCalledWith(
-      expect.stringMatching(/Photo processing failed/),
+      expect.stringMatching(/Failed to save photo/),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Migrates tg-bot idea_dobot handlers (text/voice/photo) into dobot-server as `src/handlers/idea-capture.ts`
- Wires a second grammY bot (`IDEA_BOT_TOKEN`) in `index.ts` — graceful no-op if env var missing
- Adds `IDEA_FILE` and `IDEA_ALLOWED_USER_IDS` to config
- Confirmation button uses `t.me/claude_do_bot/pocket?startapp=<path>` CPC deep-link (no share-doc URL)

## Sub-issues

- Closes #60 (migrate text/voice/photo handlers)
- Closes #61 (wire IDEA_BOT_TOKEN + dual-bot index.ts)
- Closes #62 (replace share-doc URL with t.me deep-link)
- #63 (decommission tg-bot service — ops, after merge)

## Test plan

- [ ] `pnpm run build` passes with no TypeScript errors
- [ ] `pnpm test` passes including new `idea-capture.test.ts`
- [ ] Text message saved test passes
- [ ] Unknown user rejected test passes
- [ ] Voice transcribed and saved test passes (mocked)
- [ ] Code reviewed before merge

Closes #43