### PR TITLE
feat(gateway): shared gateway routing layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,9 @@ NARRATOR_STORIES_DIR=/home/claude/claudes-world/.world/stories
 NARRATOR_VPS_SHARE_DIR=/home/claude/shared/private/tmp
 NARRATOR_VPS_SHARE_URL_BASE=https://shared.claude.do/private/tmp
 NARRATOR_TMP_DIR=/tmp
-NARRATOR_ALLOWED_USER_IDS=1676859445
+# NARRATOR_ALLOWED_USER_IDS — REMOVED: access control is now handled by agents/narrator/gateway.json
+# IDEA_ALLOWED_USER_IDS — REMOVED: access control is now handled by agents/idea-capture/gateway.json
+# IDEA_FILE — REMOVED: idea capture now writes per-file to captured-ideas/<folder>/ under the repo
 NARRATOR_CLASSIFY_MODEL=claude-haiku-4-5
 NARRATOR_REWRITE_MODEL=claude-sonnet-4-6
 NARRATOR_AGENT_RUN_SCRIPT=/home/claude/claudes-world/agents/narrator/run.sh

--- a/.env.schema
+++ b/.env.schema
@@ -24,7 +24,6 @@ NARRATOR_STORIES_DIR=/home/claude/claudes-world/.world/stories
 NARRATOR_VPS_SHARE_DIR=/home/claude/shared/private/tmp
 NARRATOR_VPS_SHARE_URL_BASE=https://shared.claude.do/private/tmp
 NARRATOR_TMP_DIR=/tmp
-NARRATOR_ALLOWED_USER_IDS=1676859445
 NARRATOR_CLASSIFY_MODEL=claude-haiku-4-5
 NARRATOR_REWRITE_MODEL=claude-sonnet-4-6
 NARRATOR_AGENT_RUN_SCRIPT=/home/claude/claudes-world/agents/narrator/run.sh

--- a/agents/idea-capture/gateway.json
+++ b/agents/idea-capture/gateway.json
@@ -31,7 +31,7 @@
   },
   {
     "handler": "idea-capture",
-    "match": { "userId": 1676859445 },
+    "match": { "userId": 1676859445, "chatType": "private" },
     "context": { "repo": "/home/claude/claudes-world", "folder": "liam-dm" },
     "label": "DMs from Liam"
   }

--- a/agents/idea-capture/gateway.json
+++ b/agents/idea-capture/gateway.json
@@ -1,0 +1,38 @@
+[
+  {
+    "handler": "idea-capture",
+    "match": { "chatId": -1003943548415, "threadId": 2 },
+    "context": { "repo": "/home/claude/claudes-world", "folder": "todo-cpc-world" },
+    "label": "TODO group — CPC World thread"
+  },
+  {
+    "handler": "idea-capture",
+    "match": { "chatId": -1003943548415, "threadId": 11 },
+    "context": { "repo": "/home/claude/claudes-world", "folder": "todo-omnipass" },
+    "label": "TODO group — OmniPass thread"
+  },
+  {
+    "handler": "idea-capture",
+    "match": { "chatId": -1003920610203, "threadId": 2 },
+    "context": { "repo": "/home/claude/claudes-world", "folder": "pulse-play-idea-capture" },
+    "label": "Pulse Play Corp — Idea Capture thread"
+  },
+  {
+    "handler": "idea-capture",
+    "match": { "chatId": -1003943548415 },
+    "context": { "repo": "/home/claude/claudes-world", "folder": "todo-general" },
+    "label": "TODO group — general fallback"
+  },
+  {
+    "handler": "idea-capture",
+    "match": { "chatId": -1003920610203 },
+    "context": { "repo": "/home/claude/claudes-world", "folder": "pulse-play-general" },
+    "label": "Pulse Play Corp — general fallback"
+  },
+  {
+    "handler": "idea-capture",
+    "match": { "userId": 1676859445 },
+    "context": { "repo": "/home/claude/claudes-world", "folder": "liam-dm" },
+    "label": "DMs from Liam"
+  }
+]

--- a/agents/narrator/gateway.json
+++ b/agents/narrator/gateway.json
@@ -1,0 +1,7 @@
+[
+  {
+    "handler": "narrator",
+    "match": { "chatType": "private", "userId": [1676859445, 7757261871] },
+    "label": "Narrator — DM from allowed users"
+  }
+]

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,16 +19,9 @@ export const config = {
   telegramIdeaBotToken: process.env['TELEGRAM_IDEA_BOT_TOKEN'],
   dobotDbPath: optional('DOBOT_DB_PATH', '/home/claude/.local/share/dobot-server/state.db'),
   ideaCapture: {
-    allowedUserIds: new Set(
-      optional('IDEA_ALLOWED_USER_IDS', '').split(',').filter(Boolean).map(Number)
-    ),
-    ideaFile: optional('IDEA_FILE', '/home/claude/ideas.md'),
     photosDir: path.resolve(process.env['IDEA_PHOTOS_DIR'] ?? path.join(os.homedir(), 'ideas-photos')),
   },
   narrator: {
-    allowedUserIds: new Set(
-      optional('NARRATOR_ALLOWED_USER_IDS', '').split(',').filter(Boolean).map(Number)
-    ),
     agentRunScript: optional('NARRATOR_AGENT_RUN_SCRIPT', '/home/claude/claudes-world/agents/narrator/run.sh'),
     narratorRoot: optional('NARRATOR_ROOT', path.resolve(__dirname, '..', 'agents', 'narrator')),
     classifyModel: optional('NARRATOR_CLASSIFY_MODEL', 'claude-haiku-4-5'),

--- a/src/gateway/dispatcher.ts
+++ b/src/gateway/dispatcher.ts
@@ -1,0 +1,25 @@
+import { Context } from 'grammy';
+import { getGatewayMatch } from './middleware.js';
+
+export type GatewayHandler = (ctx: Context, gatewayCTX: unknown) => Promise<void>;
+
+/**
+ * Dispatch ctx to the handler named by the matched gateway rule.
+ * Reads the matched rule from the WeakMap attached by the middleware.
+ * No-op if no match is attached (message was dropped before reaching here).
+ * Throws if the matched handler name is not in the handlers map.
+ */
+export async function dispatchMessage(
+  ctx: Context,
+  handlers: Record<string, GatewayHandler>,
+): Promise<void> {
+  const match = getGatewayMatch(ctx);
+  if (!match) return;
+
+  const { rule, context } = match;
+  const handler = handlers[rule.handler];
+  if (!handler) {
+    throw new Error(`gateway: no handler registered for "${rule.handler}"`);
+  }
+  await handler(ctx, context);
+}

--- a/src/gateway/match.ts
+++ b/src/gateway/match.ts
@@ -30,7 +30,9 @@ function testRule(ctx: Context, rule: GatewayRule, botUsername?: string): boolea
   }
 
   if (match.threadId !== undefined) {
-    const threadId = ctx.message?.message_thread_id;
+    // ctx.msg normalises across update types (message, edited_message, callback_query, etc.)
+    // ctx.message is undefined on callback_query/edited_message — do NOT use it here.
+    const threadId = ctx.msg?.message_thread_id;
     if (!matchScalarOrArray(threadId, match.threadId)) return false;
   }
 

--- a/src/gateway/match.ts
+++ b/src/gateway/match.ts
@@ -42,10 +42,18 @@ function testRule(ctx: Context, rule: GatewayRule, botUsername?: string): boolea
   }
 
   if (match.requireMention) {
-    const text = ctx.message?.text ?? ctx.message?.caption ?? '';
     if (!botUsername) return false;
-    const mention = `@${botUsername}`;
-    if (!text.includes(mention)) return false;
+    // Use Telegram mention entities for exact-boundary match. This prevents
+    // substring bypass where "@botUsername_evil" would satisfy a naive
+    // text.includes("@botUsername") check. Entities give exact offset+length
+    // bounds that Telegram itself assigns when rendering the mention.
+    const text = ctx.msg?.text ?? ctx.msg?.caption ?? '';
+    const entities = ctx.msg?.entities ?? ctx.msg?.caption_entities ?? [];
+    const mentionTag = `@${botUsername}`;
+    const mentioned = entities.some(
+      (e) => e.type === 'mention' && text.slice(e.offset, e.offset + e.length) === mentionTag,
+    );
+    if (!mentioned) return false;
   }
 
   return true;

--- a/src/gateway/match.ts
+++ b/src/gateway/match.ts
@@ -1,0 +1,61 @@
+import { Context } from 'grammy';
+import { GatewayRule } from './types.js';
+
+function matchScalarOrArray(value: number | undefined, condition: number | number[]): boolean {
+  if (value === undefined) return false;
+  return Array.isArray(condition) ? condition.includes(value) : value === condition;
+}
+
+function matchStringScalarOrArray(value: string | undefined, condition: string | string[]): boolean {
+  if (value === undefined) return false;
+  return Array.isArray(condition) ? condition.includes(value) : value === condition;
+}
+
+/**
+ * Test a single rule against the incoming ctx.
+ * All specified match fields must satisfy (AND logic).
+ * Returns true if all conditions pass.
+ */
+function testRule(ctx: Context, rule: GatewayRule, botUsername?: string): boolean {
+  const { match } = rule;
+
+  if (match.userId !== undefined) {
+    const userId = ctx.from?.id;
+    if (!matchScalarOrArray(userId, match.userId)) return false;
+  }
+
+  if (match.chatId !== undefined) {
+    const chatId = ctx.chat?.id;
+    if (!matchScalarOrArray(chatId, match.chatId)) return false;
+  }
+
+  if (match.threadId !== undefined) {
+    const threadId = ctx.message?.message_thread_id;
+    if (!matchScalarOrArray(threadId, match.threadId)) return false;
+  }
+
+  if (match.chatType !== undefined) {
+    const chatType = ctx.chat?.type;
+    if (!matchStringScalarOrArray(chatType, match.chatType)) return false;
+  }
+
+  if (match.requireMention) {
+    const text = ctx.message?.text ?? ctx.message?.caption ?? '';
+    if (!botUsername) return false;
+    const mention = `@${botUsername}`;
+    if (!text.includes(mention)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Find the first rule in rules[] that matches ctx.
+ * Returns the matched rule or null if none match.
+ */
+export function matchRule(ctx: Context, rules: GatewayRule[], botUsername?: string): GatewayRule | null {
+  for (const rule of rules) {
+    if (testRule(ctx, rule, botUsername)) return rule;
+  }
+  return null;
+}

--- a/src/gateway/middleware.ts
+++ b/src/gateway/middleware.ts
@@ -1,0 +1,33 @@
+import { Context, NextFunction } from 'grammy';
+import { GatewayRule } from './types.js';
+import { matchRule } from './match.js';
+
+export interface GatewayMatch {
+  rule: GatewayRule;
+  context: Record<string, unknown> | undefined;
+}
+
+// WeakMap keyed on ctx object — attaches matched gateway result to ctx lifetime
+const gatewayMatches = new WeakMap<object, GatewayMatch>();
+
+/**
+ * Read the gateway match attached to ctx by the middleware.
+ * Returns undefined if the middleware hasn't run or the message was dropped.
+ */
+export function getGatewayMatch(ctx: Context): GatewayMatch | undefined {
+  return gatewayMatches.get(ctx);
+}
+
+/**
+ * Create a grammY middleware that gates messages against gateway rules.
+ * No match → silent drop (next() not called).
+ * Match → attaches { rule, context } to ctx via WeakMap, then calls next().
+ */
+export function createGatewayMiddleware(rules: GatewayRule[], botUsername?: string) {
+  return async function gatewayMiddleware(ctx: Context, next: NextFunction): Promise<void> {
+    const matched = matchRule(ctx, rules, botUsername);
+    if (!matched) return; // silent drop
+    gatewayMatches.set(ctx, { rule: matched, context: matched.context });
+    await next();
+  };
+}

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -1,0 +1,14 @@
+export interface MatchConditions {
+  userId?: number | number[];
+  chatId?: number | number[];
+  threadId?: number | number[];
+  chatType?: 'private' | 'group' | 'supergroup' | 'channel' | string[];
+  requireMention?: boolean;
+}
+
+export interface GatewayRule {
+  handler: string;
+  match: MatchConditions;
+  context?: Record<string, unknown>;
+  label?: string;
+}

--- a/src/gateway/validate.ts
+++ b/src/gateway/validate.ts
@@ -1,0 +1,43 @@
+import type { GatewayRule } from './types.js';
+
+/**
+ * Validate a parsed gateway rules array at startup.
+ * Throws on the first invalid rule so the process fails-closed rather than
+ * silently routing all traffic through a zero-condition wildcard.
+ */
+export function validateGatewayRules(rules: GatewayRule[], agentLabel?: string): void {
+  // Keys that contribute a real runtime condition when present.
+  // NOTE: requireMention is excluded here and handled separately — the runtime
+  // check in testRule is `if (match.requireMention)` (truthy), so an explicit
+  // `requireMention: false` contributes NO condition. Counting it as present
+  // would let `{ requireMention: false }` slip through as an allow-all rule.
+  const CONDITION_KEYS: Array<keyof GatewayRule['match']> = [
+    'chatType', 'chatId', 'threadId', 'userId',
+  ];
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    const label = rule.label ?? `index ${i}`;
+    const agent = agentLabel ? ` in agent '${agentLabel}'` : '';
+
+    // Defensive: a rule with missing or non-object `match` is malformed
+    // and would crash with TypeError on property access below. Fail-closed
+    // with a descriptive error rather than a stack trace.
+    if (!rule.match || typeof rule.match !== 'object') {
+      throw new Error(
+        `Gateway rule '${label}'${agent} is missing the 'match' object — refusing to load. ` +
+        `Every rule must declare at least one of: chatType, chatId, threadId, userId, requireMention.`,
+      );
+    }
+
+    const hasCondition =
+      CONDITION_KEYS.some(k => rule.match[k] !== undefined) ||
+      rule.match.requireMention === true;
+    if (!hasCondition) {
+      throw new Error(
+        `Gateway rule '${label}'${agent} has empty match — refusing to load (would allow-all). ` +
+        `Add at least one of: chatType, chatId, threadId, userId, requireMention.`,
+      );
+    }
+  }
+}

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -1,11 +1,15 @@
-import { Context, InlineKeyboard, Bot } from 'grammy';
+import { Context, Bot } from 'grammy';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { execa } from 'execa';
 import { config } from '../config.js';
-import { toBase64url } from '../lib/telegram.js';
+
+export interface IdeaCaptureCTX {
+  repo: string;
+  folder: string;
+}
 
 /** Format the "from" field: "Display Name (@username)" or just "Display Name". */
 function formatFrom(ctx: Context): string {
@@ -13,6 +17,22 @@ function formatFrom(ctx: Context): string {
   if (!user) return 'unknown';
   const name = [user.first_name, user.last_name].filter(Boolean).join(' ');
   return user.username ? `${name} (@${user.username})` : name;
+}
+
+/** Format a filename-safe timestamp: YYYY-MM-DD-HH-MM-SS in Eastern Time. */
+function fileTimestampET(date: Date): string {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(date).map(p => [p.type, p.value]));
+  return `${parts.year}-${parts.month}-${parts.day}-${parts.hour}-${parts.minute}-${parts.second}`;
 }
 
 /** Get ISO8601 timestamp in Eastern Time. */
@@ -28,7 +48,6 @@ function isoTimestampET(date: Date): string {
     hour12: false,
   });
   const parts = Object.fromEntries(fmt.formatToParts(date).map(p => [p.type, p.value]));
-  // Determine ET offset (EDT = -04:00, EST = -05:00)
   const tzFmt = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York',
     timeZoneName: 'short',
@@ -63,52 +82,46 @@ async function downloadTelegramFile(bot: Bot, fileId: string, destPath: string, 
   await fs.writeFile(destPath, buf);
 }
 
-/** Append an idea entry to the idea file. */
-async function appendIdea(opts: {
+/** Write an idea to a per-file path under the ideas directory. */
+async function writeIdeaFile(opts: {
+  ideasDir: string;
+  timestamp: string;
   type: 'text' | 'voice' | 'photo';
   from: string;
-  timestamp: string;
+  isoTimestamp: string;
   body: string;
   photoPath?: string;
 }): Promise<void> {
-  const { type, from, timestamp, body, photoPath } = opts;
+  const { ideasDir, timestamp, type, from, isoTimestamp, body, photoPath } = opts;
+  await fs.mkdir(ideasDir, { recursive: true });
+  const uuid = randomUUID();
+  const filePath = path.join(ideasDir, `${timestamp}-${uuid}.md`);
   const photoLine = photoPath ? `![photo](${photoPath}) ` : '';
-  const entry = `---\n## ${type} idea — ${timestamp}\n**From:** ${from}\n\n${photoLine}${body}\n\n`;
-  await fs.appendFile(config.ideaCapture.ideaFile, entry, 'utf8');
-}
-
-/** Build the CPC t.me deep-link button for the idea file. */
-function buildIdeaKeyboard(): InlineKeyboard {
-  const deepLink = `https://t.me/claude_do_bot/pocket?startapp=${toBase64url(config.ideaCapture.ideaFile)}`;
-  return new InlineKeyboard().url('View in Pocket', deepLink);
+  const content = `---\n## ${type} idea — ${isoTimestamp}\n**From:** ${from}\n\n${photoLine}${body}\n`;
+  await fs.writeFile(filePath, content, 'utf8');
 }
 
 /**
  * Factory — returns a grammY message handler for idea capture.
- * Handles text, voice, and photo messages.
+ * Requires pre-gated ctx from the gateway middleware.
+ * gatewayCTX provides { repo, folder } routing context.
  */
 export function createIdeaCaptureHandler(bot: Bot) {
-  return async function ideaCaptureHandler(ctx: Context): Promise<void> {
-    // DM-only
-    if (ctx.chat?.type !== 'private') return;
-
-    const userId = ctx.from?.id;
-    if (!userId) return;
-
-    // Access guard — silently reject if not in allowlist
-    if (!config.ideaCapture.allowedUserIds.has(userId)) return;
+  return async function ideaCaptureHandler(ctx: Context, gatewayCTX: unknown): Promise<void> {
+    const { repo, folder } = gatewayCTX as IdeaCaptureCTX;
+    const ideasDir = path.join(repo, 'captured-ideas', folder);
 
     const from = formatFrom(ctx);
     const now = new Date();
-    const timestamp = isoTimestampET(now);
-    const keyboard = buildIdeaKeyboard();
+    const timestamp = fileTimestampET(now);
+    const isoTimestamp = isoTimestampET(now);
 
     // --- Text message ---
     const text = ctx.message?.text;
     if (text) {
       try {
-        await appendIdea({ type: 'text', from, timestamp, body: text });
-        await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
+        await writeIdeaFile({ ideasDir, timestamp, type: 'text', from, isoTimestamp, body: text });
+        await ctx.reply('✅ Idea saved');
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[idea-capture/text] Error:', msg);
@@ -140,8 +153,8 @@ export function createIdeaCaptureHandler(bot: Bot) {
           return;
         }
 
-        await appendIdea({ type: 'voice', from, timestamp, body: transcribed });
-        await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
+        await writeIdeaFile({ ideasDir, timestamp, type: 'voice', from, isoTimestamp, body: transcribed });
+        await ctx.reply('✅ Idea saved');
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[idea-capture/voice] Error:', msg);
@@ -155,7 +168,6 @@ export function createIdeaCaptureHandler(bot: Bot) {
     // --- Photo message ---
     const photos = ctx.message?.photo;
     if (photos && photos.length > 0) {
-      // Telegram sends photos sorted by size — take the largest
       const largest = photos[photos.length - 1];
       const permanentPath = path.join(config.ideaCapture.photosDir, `idea-photo-${randomUUID()}.jpg`);
       let recorded = false;
@@ -171,15 +183,13 @@ export function createIdeaCaptureHandler(bot: Bot) {
         }
 
         const caption = ctx.message?.caption ?? '';
-        const relPath = path.relative(path.dirname(config.ideaCapture.ideaFile), permanentPath);
-        await appendIdea({ type: 'photo', from, timestamp, body: caption, photoPath: relPath });
-        recorded = true;  // file is now referenced in the idea entry
-        await ctx.reply('✅ Idea saved', { reply_markup: keyboard });
+        await writeIdeaFile({ ideasDir, timestamp, type: 'photo', from, isoTimestamp, body: caption, photoPath: permanentPath });
+        recorded = true;
+        await ctx.reply('✅ Idea saved');
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[idea-capture/photo] Error:', msg);
         if (!recorded) {
-          // Only clean up if the entry was never committed
           try { await fs.unlink(permanentPath); } catch { }
         }
         await ctx.reply('⚠️ Failed to save photo').catch(() => {});

--- a/src/handlers/idea-capture.ts
+++ b/src/handlers/idea-capture.ts
@@ -108,7 +108,17 @@ async function writeIdeaFile(opts: {
  */
 export function createIdeaCaptureHandler(bot: Bot) {
   return async function ideaCaptureHandler(ctx: Context, gatewayCTX: unknown): Promise<void> {
-    const { repo, folder } = gatewayCTX as IdeaCaptureCTX;
+    const gc = (gatewayCTX && typeof gatewayCTX === 'object')
+      ? (gatewayCTX as Partial<IdeaCaptureCTX>)
+      : undefined;
+    if (!gc || !gc.repo || !gc.folder) {
+      console.warn(
+        `[idea-capture] invoked without valid context — expected {repo, folder}, ` +
+        `got ${JSON.stringify(gc)}. Dropping message.`,
+      );
+      return;
+    }
+    const { repo, folder } = gc;
     const ideasDir = path.join(repo, 'captured-ideas', folder);
 
     const from = formatFrom(ctx);

--- a/src/handlers/narrator.ts
+++ b/src/handlers/narrator.ts
@@ -65,14 +65,8 @@ function userFacingError(err: unknown): string {
 
 export function createNarratorHandler(db: Database.Database) {
   return async function narratorHandler(ctx: Context): Promise<void> {
-    // DM-only — silently reject group/supergroup/channel messages (#47)
-    if (ctx.chat?.type !== 'private') return;
-
     const userId = ctx.from?.id;
     if (!userId) return;
-
-    // 1. Filter — silently reject if not in allowlist
-    if (!config.narrator.allowedUserIds.has(userId)) return;
 
     // 1a. Forwarded message detection — check before plain text extraction
     // Note: forward_origin is the canonical forwarded-message indicator in Bot API 7.x+.
@@ -532,8 +526,6 @@ export function createCancelHandler(db: Database.Database) {
   return async function cancelHandler(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
     if (!userId) return;
-
-    if (!config.narrator.allowedUserIds.has(userId)) return;
 
     const chatId = ctx.chat!.id;
     const active = activeJobs.get(chatId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,16 @@ import { createIdeaCaptureHandler } from './handlers/idea-capture.js';
 import { createGatewayMiddleware } from './gateway/middleware.js';
 import { dispatchMessage } from './gateway/dispatcher.js';
 import type { GatewayRule } from './gateway/types.js';
+import { validateGatewayRules } from './gateway/validate.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function loadGatewayRules(agentDir: string): GatewayRule[] {
   const gatewayPath = path.resolve(__dirname, '..', 'agents', agentDir, 'gateway.json');
   const raw = readFileSync(gatewayPath, 'utf8');
-  return JSON.parse(raw) as GatewayRule[];
+  const rules = JSON.parse(raw) as GatewayRule[];
+  validateGatewayRules(rules, agentDir);
+  return rules;
 }
 
 async function main(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import './lib/otel.js';
 import 'dotenv/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
 import { Bot } from 'grammy';
 import { config } from './config.js';
 import { createBot } from './bot-factory.js';
@@ -9,6 +12,17 @@ import { registerHandlers } from './router.js';
 import { createNarratorHandler, continueNarration, createCancelHandler } from './handlers/narrator.js';
 import { createLengthCallbackHandler } from './handlers/narrator-callback.js';
 import { createIdeaCaptureHandler } from './handlers/idea-capture.js';
+import { createGatewayMiddleware } from './gateway/middleware.js';
+import { dispatchMessage } from './gateway/dispatcher.js';
+import type { GatewayRule } from './gateway/types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadGatewayRules(agentDir: string): GatewayRule[] {
+  const gatewayPath = path.resolve(__dirname, '..', 'agents', agentDir, 'gateway.json');
+  const raw = readFileSync(gatewayPath, 'utf8');
+  return JSON.parse(raw) as GatewayRule[];
+}
 
 async function main(): Promise<void> {
   const db = openDatabase(config.dobotDbPath);
@@ -21,6 +35,10 @@ async function main(): Promise<void> {
   const me = await narratorBot.api.getMe();
   rebuildPendingTimeouts(db, narratorBot.api, me,
     (jobId, length, ctx, toneOverride, shapeOverride, ackMessageId) => continueNarration(jobId, length, ctx, db, toneOverride, shapeOverride, ackMessageId));
+
+  // Load narrator gateway rules and apply middleware
+  const narratorRules = loadGatewayRules('narrator');
+  narratorBot.use(createGatewayMiddleware(narratorRules, me.username));
 
   registerHandlers(narratorBot, {
     narrator: createNarratorHandler(db),
@@ -35,13 +53,21 @@ async function main(): Promise<void> {
   const ideaBotToken = config.telegramIdeaBotToken;
   if (ideaBotToken) {
     ideaBot = createBot(ideaBotToken);
-    ideaBot.on('message', createIdeaCaptureHandler(ideaBot));
+
+    // Load idea-capture gateway rules and apply middleware
+    const ideaRules = loadGatewayRules('idea-capture');
+    const ideaMe = await ideaBot.api.getMe();
+    ideaBot.use(createGatewayMiddleware(ideaRules, ideaMe.username));
+
+    const ideaCaptureHandler = createIdeaCaptureHandler(ideaBot);
+    ideaBot.on('message', async (ctx) => {
+      await dispatchMessage(ctx, {
+        'idea-capture': ideaCaptureHandler,
+      });
+    });
     ideaBot.catch((err) => {
       console.error('ideaBot: unhandled error in handler', err);
     });
-    if (config.ideaCapture.allowedUserIds.size === 0) {
-      console.warn('dobot-server: IDEA_ALLOWED_USER_IDS is not set — idea bot will reject all messages');
-    }
     console.log('dobot-server: idea capture bot enabled');
   } else {
     console.warn('dobot-server: TELEGRAM_IDEA_BOT_TOKEN not set — idea capture bot disabled');

--- a/test/gateway/dispatcher.test.ts
+++ b/test/gateway/dispatcher.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dispatchMessage } from '../../src/gateway/dispatcher.js';
+import { createGatewayMiddleware } from '../../src/gateway/middleware.js';
+import type { GatewayRule } from '../../src/gateway/types.js';
+import type { Context } from 'grammy';
+
+function makeCtx(overrides: Record<string, unknown> = {}): Context {
+  return {
+    from: { id: 1 },
+    chat: { id: 1, type: 'private' },
+    message: { text: 'hello' },
+    ...overrides,
+  } as unknown as Context;
+}
+
+async function runMiddleware(ctx: Context, rules: GatewayRule[]): Promise<void> {
+  const mw = createGatewayMiddleware(rules);
+  await mw(ctx, () => Promise.resolve());
+}
+
+describe('dispatchMessage', () => {
+  it('invokes the matched handler with ctx and gatewayCTX', async () => {
+    const rules: GatewayRule[] = [
+      { handler: 'idea-capture', match: { chatType: 'private' }, context: { repo: '/tmp', folder: 'test' } },
+    ];
+    const ctx = makeCtx();
+    await runMiddleware(ctx, rules);
+
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await dispatchMessage(ctx, { 'idea-capture': handler });
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [calledCtx, calledGatewayCTX] = handler.mock.calls[0] as [Context, unknown];
+    expect(calledCtx).toBe(ctx);
+    expect(calledGatewayCTX).toEqual({ repo: '/tmp', folder: 'test' });
+  });
+
+  it('is a no-op when no gateway match is attached (message was dropped)', async () => {
+    const ctx = makeCtx();
+    // No middleware run — no match attached
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await dispatchMessage(ctx, { 'h': handler });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('throws when matched handler name is not in the map', async () => {
+    const rules: GatewayRule[] = [
+      { handler: 'missing-handler', match: { chatType: 'private' } },
+    ];
+    const ctx = makeCtx();
+    await runMiddleware(ctx, rules);
+
+    await expect(dispatchMessage(ctx, {})).rejects.toThrow('no handler registered for "missing-handler"');
+  });
+
+  it('passes undefined gatewayCTX when rule has no context field', async () => {
+    const rules: GatewayRule[] = [
+      { handler: 'narrator', match: { chatType: 'private' } },
+    ];
+    const ctx = makeCtx();
+    await runMiddleware(ctx, rules);
+
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await dispatchMessage(ctx, { narrator: handler });
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [, calledGatewayCTX] = handler.mock.calls[0] as [Context, unknown];
+    expect(calledGatewayCTX).toBeUndefined();
+  });
+});

--- a/test/gateway/match.test.ts
+++ b/test/gateway/match.test.ts
@@ -3,17 +3,37 @@ import { matchRule } from '../../src/gateway/match.js';
 import type { GatewayRule } from '../../src/gateway/types.js';
 import type { Context } from 'grammy';
 
+// Auto-generate Telegram-style `mention` entities for every `@handle` token in
+// the given text. Production Telegram attaches these for any well-formed
+// @username in a message body; reproducing that behaviour here keeps tests
+// realistic and mirrors how the matcher consumes `ctx.msg.entities`.
+function autoMentionEntities(text: string): Array<{ type: string; offset: number; length: number }> {
+  const entities: Array<{ type: string; offset: number; length: number }> = [];
+  const re = /@[A-Za-z0-9_]+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    entities.push({ type: 'mention', offset: m.index, length: m[0].length });
+  }
+  return entities;
+}
+
 function makeCtx(overrides: {
   userId?: number;
   chatId?: number;
   chatType?: string;
   threadId?: number;
   text?: string;
+  entities?: Array<{ type: string; offset: number; length: number }>;
 } = {}): Context {
-  const msgFields = {
+  const msgFields: Record<string, unknown> = {
     ...(overrides.threadId !== undefined ? { message_thread_id: overrides.threadId } : {}),
     ...(overrides.text !== undefined ? { text: overrides.text } : {}),
   };
+  if (overrides.text !== undefined) {
+    msgFields.entities = overrides.entities ?? autoMentionEntities(overrides.text);
+  } else if (overrides.entities !== undefined) {
+    msgFields.entities = overrides.entities;
+  }
   // Populate both ctx.message and ctx.msg (grammY alias) so threadId tests work
   // regardless of update type. In production grammY populates ctx.msg automatically.
   return {
@@ -119,6 +139,49 @@ describe('matchRule — requireMention', () => {
     ];
     const ctx = makeCtx({ chatId: 1, chatType: 'group', text: 'hey @mybot do this' });
     expect(matchRule(ctx, rules)).toBeNull();
+  });
+
+  it('matches exact-boundary @botUsername via entities', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: true } },
+    ];
+    const ctx = makeCtx({
+      chatId: 1,
+      chatType: 'group',
+      text: 'hey @claude_do_bot help',
+    });
+    expect(matchRule(ctx, rules, 'claude_do_bot')).toBeTruthy();
+  });
+
+  it('no match on substring bypass @botUsername_evil (entities guard)', () => {
+    // Without entity-based matching this would have passed a naive
+    // text.includes("@claude_do_bot") check. The mention entity covers the
+    // full "@claude_do_bot_evil" span, so strict length-equality rejects it.
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: true } },
+    ];
+    const ctx = makeCtx({
+      chatId: 1,
+      chatType: 'group',
+      text: 'hey @claude_do_bot_evil help',
+    });
+    expect(matchRule(ctx, rules, 'claude_do_bot')).toBeNull();
+  });
+
+  it('no match when @botUsername appears only as plain text (no mention entity)', () => {
+    // If Telegram didn't tag the token as a mention entity (e.g. inside a
+    // code block), requireMention should still reject it — exact-boundary
+    // semantics require an entity.
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: true } },
+    ];
+    const ctx = makeCtx({
+      chatId: 1,
+      chatType: 'group',
+      text: 'hey @claude_do_bot help',
+      entities: [],
+    });
+    expect(matchRule(ctx, rules, 'claude_do_bot')).toBeNull();
   });
 });
 

--- a/test/gateway/match.test.ts
+++ b/test/gateway/match.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { matchRule } from '../../src/gateway/match.js';
+import type { GatewayRule } from '../../src/gateway/types.js';
+import type { Context } from 'grammy';
+
+function makeCtx(overrides: {
+  userId?: number;
+  chatId?: number;
+  chatType?: string;
+  threadId?: number;
+  text?: string;
+} = {}): Context {
+  return {
+    from: overrides.userId !== undefined ? { id: overrides.userId } : undefined,
+    chat: overrides.chatId !== undefined
+      ? { id: overrides.chatId, type: overrides.chatType ?? 'private' }
+      : undefined,
+    message: {
+      ...(overrides.threadId !== undefined ? { message_thread_id: overrides.threadId } : {}),
+      ...(overrides.text !== undefined ? { text: overrides.text } : {}),
+    },
+  } as unknown as Context;
+}
+
+describe('matchRule — single rule matching', () => {
+  it('matches userId scalar', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { userId: 42 } },
+    ];
+    expect(matchRule(makeCtx({ userId: 42 }), rules)).toBeTruthy();
+    expect(matchRule(makeCtx({ userId: 99 }), rules)).toBeNull();
+  });
+
+  it('matches userId array (OR within field)', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { userId: [1, 2, 3] } },
+    ];
+    expect(matchRule(makeCtx({ userId: 2 }), rules)).toBeTruthy();
+    expect(matchRule(makeCtx({ userId: 4 }), rules)).toBeNull();
+  });
+
+  it('matches chatId scalar', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatId: -100 } },
+    ];
+    expect(matchRule(makeCtx({ chatId: -100, chatType: 'supergroup' }), rules)).toBeTruthy();
+    expect(matchRule(makeCtx({ chatId: -200, chatType: 'supergroup' }), rules)).toBeNull();
+  });
+
+  it('matches chatId array', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatId: [-100, -200] } },
+    ];
+    expect(matchRule(makeCtx({ chatId: -200, chatType: 'group' }), rules)).toBeTruthy();
+    expect(matchRule(makeCtx({ chatId: -300, chatType: 'group' }), rules)).toBeNull();
+  });
+
+  it('matches threadId scalar', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatId: -100, threadId: 5 } },
+    ];
+    expect(matchRule(makeCtx({ chatId: -100, chatType: 'supergroup', threadId: 5 }), rules)).toBeTruthy();
+    expect(matchRule(makeCtx({ chatId: -100, chatType: 'supergroup', threadId: 6 }), rules)).toBeNull();
+  });
+
+  it('matches chatType scalar', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: 'private' } },
+    ];
+    expect(matchRule(makeCtx({ chatId: 1, chatType: 'private' }), rules)).toBeTruthy();
+    expect(matchRule(makeCtx({ chatId: 1, chatType: 'supergroup' }), rules)).toBeNull();
+  });
+
+  it('matches chatType array', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: ['group', 'supergroup'] } },
+    ];
+    expect(matchRule(makeCtx({ chatId: 1, chatType: 'supergroup' }), rules)).toBeTruthy();
+    expect(matchRule(makeCtx({ chatId: 1, chatType: 'private' }), rules)).toBeNull();
+  });
+
+  it('AND logic — all fields must match', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: 'private', userId: [1, 2] } },
+    ];
+    // Both conditions pass
+    expect(matchRule(makeCtx({ chatId: 1, chatType: 'private', userId: 1 }), rules)).toBeTruthy();
+    // chatType passes, userId fails
+    expect(matchRule(makeCtx({ chatId: 1, chatType: 'private', userId: 3 }), rules)).toBeNull();
+    // userId passes, chatType fails
+    expect(matchRule(makeCtx({ chatId: 1, chatType: 'group', userId: 1 }), rules)).toBeNull();
+  });
+});
+
+describe('matchRule — requireMention', () => {
+  it('matches when bot is mentioned in text', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: true } },
+    ];
+    const ctx = makeCtx({ chatId: 1, chatType: 'group', text: 'hey @mybot do this' });
+    expect(matchRule(ctx, rules, 'mybot')).toBeTruthy();
+  });
+
+  it('no match when bot not mentioned', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: true } },
+    ];
+    const ctx = makeCtx({ chatId: 1, chatType: 'group', text: 'hey do this' });
+    expect(matchRule(ctx, rules, 'mybot')).toBeNull();
+  });
+
+  it('no match when botUsername not provided', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: true } },
+    ];
+    const ctx = makeCtx({ chatId: 1, chatType: 'group', text: 'hey @mybot do this' });
+    expect(matchRule(ctx, rules)).toBeNull();
+  });
+});
+
+describe('matchRule — first-wins ordering', () => {
+  it('returns first matching rule', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'specific', match: { chatId: -100, threadId: 5 } },
+      { handler: 'fallback', match: { chatId: -100 } },
+    ];
+    const specificCtx = makeCtx({ chatId: -100, chatType: 'supergroup', threadId: 5 });
+    const fallbackCtx = makeCtx({ chatId: -100, chatType: 'supergroup', threadId: 9 });
+
+    expect(matchRule(specificCtx, rules)?.handler).toBe('specific');
+    expect(matchRule(fallbackCtx, rules)?.handler).toBe('fallback');
+  });
+
+  it('returns null when no rule matches', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatId: -100 } },
+    ];
+    expect(matchRule(makeCtx({ chatId: -999, chatType: 'supergroup' }), rules)).toBeNull();
+  });
+
+  it('empty rules array returns null', () => {
+    expect(matchRule(makeCtx({ chatId: 1 }), [])).toBeNull();
+  });
+});
+
+describe('matchRule — undefined ctx fields', () => {
+  it('userId condition fails when ctx.from is undefined', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { userId: 1 } },
+    ];
+    const ctx = { from: undefined, chat: { id: 1, type: 'private' }, message: {} } as unknown as Context;
+    expect(matchRule(ctx, rules)).toBeNull();
+  });
+
+  it('chatId condition fails when ctx.chat is undefined', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatId: 1 } },
+    ];
+    const ctx = { from: { id: 1 }, chat: undefined, message: {} } as unknown as Context;
+    expect(matchRule(ctx, rules)).toBeNull();
+  });
+
+  it('threadId condition fails when message_thread_id is undefined', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { threadId: 5 } },
+    ];
+    const ctx = makeCtx({ chatId: -100, chatType: 'supergroup' });
+    expect(matchRule(ctx, rules)).toBeNull();
+  });
+});

--- a/test/gateway/match.test.ts
+++ b/test/gateway/match.test.ts
@@ -10,15 +10,19 @@ function makeCtx(overrides: {
   threadId?: number;
   text?: string;
 } = {}): Context {
+  const msgFields = {
+    ...(overrides.threadId !== undefined ? { message_thread_id: overrides.threadId } : {}),
+    ...(overrides.text !== undefined ? { text: overrides.text } : {}),
+  };
+  // Populate both ctx.message and ctx.msg (grammY alias) so threadId tests work
+  // regardless of update type. In production grammY populates ctx.msg automatically.
   return {
     from: overrides.userId !== undefined ? { id: overrides.userId } : undefined,
     chat: overrides.chatId !== undefined
       ? { id: overrides.chatId, type: overrides.chatType ?? 'private' }
       : undefined,
-    message: {
-      ...(overrides.threadId !== undefined ? { message_thread_id: overrides.threadId } : {}),
-      ...(overrides.text !== undefined ? { text: overrides.text } : {}),
-    },
+    message: msgFields,
+    msg: msgFields,
   } as unknown as Context;
 }
 
@@ -140,6 +144,51 @@ describe('matchRule — first-wins ordering', () => {
 
   it('empty rules array returns null', () => {
     expect(matchRule(makeCtx({ chatId: 1 }), [])).toBeNull();
+  });
+});
+
+describe('matchRule — threadId via ctx.msg across update types', () => {
+  it('matches threadId on callback_query (ctx.message is undefined, ctx.msg is set)', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'specific', match: { chatId: -100, threadId: 5 } },
+      { handler: 'fallback', match: { chatId: -100 } },
+    ];
+    // Simulate callback_query: ctx.message is undefined, ctx.msg has message_thread_id
+    const ctx = {
+      from: { id: 1 },
+      chat: { id: -100, type: 'supergroup' },
+      message: undefined,
+      msg: { message_thread_id: 5 },
+    } as unknown as Context;
+    expect(matchRule(ctx, rules)?.handler).toBe('specific');
+  });
+
+  it('matches threadId on edited_message (ctx.message is undefined, ctx.msg is set)', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'specific', match: { chatId: -100, threadId: 5 } },
+      { handler: 'fallback', match: { chatId: -100 } },
+    ];
+    const ctx = {
+      from: { id: 1 },
+      chat: { id: -100, type: 'supergroup' },
+      message: undefined,
+      msg: { message_thread_id: 5 },
+    } as unknown as Context;
+    expect(matchRule(ctx, rules)?.handler).toBe('specific');
+  });
+
+  it('falls through to fallback rule when callback_query is in a different thread', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'specific', match: { chatId: -100, threadId: 5 } },
+      { handler: 'fallback', match: { chatId: -100 } },
+    ];
+    const ctx = {
+      from: { id: 1 },
+      chat: { id: -100, type: 'supergroup' },
+      message: undefined,
+      msg: { message_thread_id: 99 },
+    } as unknown as Context;
+    expect(matchRule(ctx, rules)?.handler).toBe('fallback');
   });
 });
 

--- a/test/gateway/middleware.test.ts
+++ b/test/gateway/middleware.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createGatewayMiddleware, getGatewayMatch } from '../../src/gateway/middleware.js';
+import type { GatewayRule } from '../../src/gateway/types.js';
+import type { Context } from 'grammy';
+
+function makeCtx(overrides: Record<string, unknown> = {}): Context {
+  return {
+    from: { id: 1 },
+    chat: { id: 1, type: 'private' },
+    message: { text: 'hello' },
+    ...overrides,
+  } as unknown as Context;
+}
+
+describe('createGatewayMiddleware', () => {
+  it('calls next() when a rule matches', async () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: 'private' } },
+    ];
+    const mw = createGatewayMiddleware(rules);
+    const ctx = makeCtx();
+    const next = vi.fn().mockResolvedValue(undefined);
+    await mw(ctx, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT call next() when no rule matches (silent drop)', async () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: 'group' } },
+    ];
+    const mw = createGatewayMiddleware(rules);
+    const ctx = makeCtx();
+    const next = vi.fn().mockResolvedValue(undefined);
+    await mw(ctx, next);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('attaches matched rule to ctx via getGatewayMatch', async () => {
+    const rules: GatewayRule[] = [
+      { handler: 'narrator', match: { chatType: 'private', userId: 1 }, context: { foo: 'bar' }, label: 'test' },
+    ];
+    const mw = createGatewayMiddleware(rules);
+    const ctx = makeCtx();
+    await mw(ctx, vi.fn().mockResolvedValue(undefined));
+    const match = getGatewayMatch(ctx);
+    expect(match).toBeDefined();
+    expect(match?.rule.handler).toBe('narrator');
+    expect(match?.context).toEqual({ foo: 'bar' });
+  });
+
+  it('does NOT attach match when no rule matches', async () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: 'group' } },
+    ];
+    const mw = createGatewayMiddleware(rules);
+    const ctx = makeCtx();
+    await mw(ctx, vi.fn().mockResolvedValue(undefined));
+    expect(getGatewayMatch(ctx)).toBeUndefined();
+  });
+
+  it('getGatewayMatch returns undefined for ctx with no middleware run', () => {
+    const ctx = makeCtx();
+    expect(getGatewayMatch(ctx)).toBeUndefined();
+  });
+});

--- a/test/gateway/validate.test.ts
+++ b/test/gateway/validate.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { validateGatewayRules } from '../../src/gateway/validate.js';
+import type { GatewayRule } from '../../src/gateway/types.js';
+
+describe('validateGatewayRules — zero-match guard', () => {
+  it('accepts rules with at least one match condition', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: 'private' } },
+      { handler: 'h2', match: { userId: 1, chatId: -100 } },
+    ];
+    expect(() => validateGatewayRules(rules)).not.toThrow();
+  });
+
+  it('rejects a rule with empty match object', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: {} },
+    ];
+    expect(() => validateGatewayRules(rules)).toThrow(/empty match/);
+    expect(() => validateGatewayRules(rules)).toThrow(/allow-all/);
+  });
+
+  it('includes the agent label in the error message', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: {} },
+    ];
+    expect(() => validateGatewayRules(rules, 'narrator')).toThrow(/agent 'narrator'/);
+  });
+
+  it('includes the rule label in the error message when present', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: {}, label: 'my-rule' },
+    ];
+    expect(() => validateGatewayRules(rules, 'idea-capture')).toThrow(/my-rule/);
+  });
+
+  it('includes the rule index when no label', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { chatType: 'private' } },
+      { handler: 'h2', match: {} },
+    ];
+    expect(() => validateGatewayRules(rules)).toThrow(/index 1/);
+  });
+
+  it('reports the first bad rule (fail-fast)', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'ok', match: { chatId: -100 } },
+      { handler: 'bad1', match: {}, label: 'first-bad' },
+      { handler: 'bad2', match: {}, label: 'second-bad' },
+    ];
+    expect(() => validateGatewayRules(rules)).toThrow(/first-bad/);
+  });
+
+  it('accepts empty rules array (no rules = no traffic, not an error)', () => {
+    expect(() => validateGatewayRules([])).not.toThrow();
+  });
+
+  it('rejects requireMention: false as not a real condition (runtime matches truthy only)', () => {
+    // requireMention: false contributes no runtime condition — testRule uses
+    // `if (match.requireMention)` (truthy check), so `false` is equivalent to
+    // the key being absent. Validator MUST treat `{ requireMention: false }`
+    // as allow-all and reject it, matching the runtime semantics.
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: false } },
+    ];
+    expect(() => validateGatewayRules(rules)).toThrow(/empty match/);
+  });
+
+  it('accepts requireMention: true as a valid condition', () => {
+    const rules: GatewayRule[] = [
+      { handler: 'h', match: { requireMention: true } },
+    ];
+    expect(() => validateGatewayRules(rules)).not.toThrow();
+  });
+
+  it('rejects a rule with missing match object (not a crash)', () => {
+    const rules = [
+      { handler: 'h' } as unknown as GatewayRule,
+    ];
+    expect(() => validateGatewayRules(rules)).toThrow(/missing the 'match' object/);
+  });
+
+  it('rejects a rule with match: null (not a crash)', () => {
+    const rules = [
+      { handler: 'h', match: null } as unknown as GatewayRule,
+    ];
+    expect(() => validateGatewayRules(rules)).toThrow(/missing the 'match' object/);
+  });
+});

--- a/test/handlers/idea-capture.test.ts
+++ b/test/handlers/idea-capture.test.ts
@@ -133,6 +133,77 @@ describe('ideaCaptureHandler — text messages', () => {
   });
 });
 
+describe('ideaCaptureHandler — gatewayCTX guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch();
+  });
+
+  it('8. Drops message (no write, no reply) when gatewayCTX is undefined', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const bot = makeBot();
+    const ctx = makeCtx();
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never, undefined);
+
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    expect(ctx.reply).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/without valid context/));
+    warnSpy.mockRestore();
+  });
+
+  it('9. Drops message when gatewayCTX is missing repo', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const bot = makeBot();
+    const ctx = makeCtx();
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never, { folder: 'liam-dm' });
+
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    expect(ctx.reply).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/without valid context/));
+    warnSpy.mockRestore();
+  });
+
+  it('10. Drops message when gatewayCTX is missing folder', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const bot = makeBot();
+    const ctx = makeCtx();
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never, { repo: '/some/repo' });
+
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    expect(ctx.reply).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/without valid context/));
+    warnSpy.mockRestore();
+  });
+
+  it('11. Drops message when gatewayCTX is a non-object (string)', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const bot = makeBot();
+    const ctx = makeCtx();
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never, 'not-an-object' as never);
+
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    expect(ctx.reply).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/without valid context/));
+    warnSpy.mockRestore();
+  });
+});
+
 describe('ideaCaptureHandler — voice messages', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/test/handlers/idea-capture.test.ts
+++ b/test/handlers/idea-capture.test.ts
@@ -6,12 +6,9 @@ vi.mock('../../src/config.js', () => ({
     telegramNarratorBotToken: 'test-narrator-token',
     telegramIdeaBotToken: 'test-idea-token',
     ideaCapture: {
-      allowedUserIds: new Set([1]),
-      ideaFile: '/tmp/test-ideas.md',
       photosDir: '/tmp/ideas-photos',
     },
     narrator: {
-      allowedUserIds: new Set([1]),
       agentRunScript: '/fake/run.sh',
       narratorRoot: '/fake/claudes-world/agents/narrator',
       classifyModel: 'claude-haiku-4-5',
@@ -47,6 +44,8 @@ vi.mock('execa', () => ({
 
 import { execa } from 'execa';
 import { createIdeaCaptureHandler } from '../../src/handlers/idea-capture.js';
+
+const TEST_GATEWAY_CTX = { repo: '/home/claude/claudes-world', folder: 'liam-dm' };
 
 function makeBot(overrides: Record<string, unknown> = {}) {
   return {
@@ -85,18 +84,22 @@ describe('ideaCaptureHandler — text messages', () => {
     mockFetch();
   });
 
-  it('1. Text message saved — appendFile called with idea content', async () => {
+  it('1. Text message saved — writeFile called with idea content', async () => {
     const { default: fsMock } = await import('node:fs/promises');
-    const appendSpy = vi.mocked(fsMock.appendFile);
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
 
     const bot = makeBot();
     const ctx = makeCtx();
     const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
+    await handler(ctx as never, TEST_GATEWAY_CTX);
 
-    expect(appendSpy).toHaveBeenCalledOnce();
-    const [filePath, content] = appendSpy.mock.calls[0] as [string, string];
-    expect(filePath).toBe('/tmp/test-ideas.md');
+    // writeFile called for the idea markdown file
+    const ideaWrite = writeFileSpy.mock.calls.find(([p]) =>
+      typeof p === 'string' && p.includes('captured-ideas')
+    );
+    expect(ideaWrite).toBeDefined();
+    const [filePath, content] = ideaWrite as [string, string];
+    expect(filePath).toMatch(/captured-ideas\/liam-dm\/\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-[0-9a-f-]+\.md$/);
     expect(content).toContain('This is my idea text');
     expect(content).toContain('text idea');
     expect(content).toContain('Liam (@liamtest)');
@@ -106,39 +109,27 @@ describe('ideaCaptureHandler — text messages', () => {
     const bot = makeBot();
     const ctx = makeCtx();
     const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
+    await handler(ctx as never, TEST_GATEWAY_CTX);
 
     expect(ctx.reply).toHaveBeenCalledOnce();
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '✅ Idea saved',
-      expect.objectContaining({ reply_markup: expect.anything() })
+    expect(ctx.reply).toHaveBeenCalledWith('✅ Idea saved');
+  });
+
+  it('3. Idea file path uses gatewayCTX repo and folder', async () => {
+    const { default: fsMock } = await import('node:fs/promises');
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
+
+    const bot = makeBot();
+    const ctx = makeCtx();
+    const handler = createIdeaCaptureHandler(bot as never);
+    await handler(ctx as never, { repo: '/some/repo', folder: 'custom-folder' });
+
+    const ideaWrite = writeFileSpy.mock.calls.find(([p]) =>
+      typeof p === 'string' && p.includes('captured-ideas')
     );
-  });
-
-  it('3. Unknown user rejected — no appendFile, no reply', async () => {
-    const { default: fsMock } = await import('node:fs/promises');
-    const appendSpy = vi.mocked(fsMock.appendFile);
-
-    const bot = makeBot();
-    const ctx = makeCtx({ from: { id: 999, first_name: 'Stranger' } });
-    const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
-
-    expect(appendSpy).not.toHaveBeenCalled();
-    expect(ctx.reply).not.toHaveBeenCalled();
-  });
-
-  it('4. Group message rejected — DM-only filter', async () => {
-    const { default: fsMock } = await import('node:fs/promises');
-    const appendSpy = vi.mocked(fsMock.appendFile);
-
-    const bot = makeBot();
-    const ctx = makeCtx({ chat: { id: -100, type: 'supergroup' } });
-    const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
-
-    expect(appendSpy).not.toHaveBeenCalled();
-    expect(ctx.reply).not.toHaveBeenCalled();
+    expect(ideaWrite).toBeDefined();
+    const [filePath] = ideaWrite as [string];
+    expect(filePath).toContain('/some/repo/captured-ideas/custom-folder/');
   });
 });
 
@@ -148,9 +139,9 @@ describe('ideaCaptureHandler — voice messages', () => {
     mockFetch();
   });
 
-  it('5. Voice message transcribed and saved', async () => {
+  it('4. Voice message transcribed and saved', async () => {
     const { default: fsMock } = await import('node:fs/promises');
-    const appendSpy = vi.mocked(fsMock.appendFile);
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
     const execaMock = vi.mocked(execa);
 
     const bot = makeBot();
@@ -162,7 +153,7 @@ describe('ideaCaptureHandler — voice messages', () => {
     });
 
     const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
+    await handler(ctx as never, TEST_GATEWAY_CTX);
 
     // execa called with transcribe binary and a temp path
     expect(execaMock).toHaveBeenCalledOnce();
@@ -170,20 +161,20 @@ describe('ideaCaptureHandler — voice messages', () => {
     expect(bin).toBe('/home/claude/bin/transcribe');
     expect(args[0]).toMatch(/idea-voice-[0-9a-f-]+\.oga$/);
 
-    // appendFile called with transcribed content
-    expect(appendSpy).toHaveBeenCalledOnce();
-    const [, content] = appendSpy.mock.calls[0] as [string, string];
+    // writeFile called with transcribed content for the idea file
+    const ideaWrite = writeFileSpy.mock.calls.find(([p]) =>
+      typeof p === 'string' && p.includes('captured-ideas')
+    );
+    expect(ideaWrite).toBeDefined();
+    const [, content] = ideaWrite as [string, string];
     expect(content).toContain('transcribed text from voice note');
     expect(content).toContain('voice idea');
 
     // Reply sent
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '✅ Idea saved',
-      expect.objectContaining({ reply_markup: expect.anything() })
-    );
+    expect(ctx.reply).toHaveBeenCalledWith('✅ Idea saved');
   });
 
-  it('6. Voice temp file cleaned up after transcription', async () => {
+  it('5. Voice temp file cleaned up after transcription', async () => {
     const { default: fsMock } = await import('node:fs/promises');
     const unlinkSpy = vi.mocked(fsMock.unlink);
 
@@ -196,7 +187,7 @@ describe('ideaCaptureHandler — voice messages', () => {
     });
 
     const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
+    await handler(ctx as never, TEST_GATEWAY_CTX);
 
     expect(unlinkSpy).toHaveBeenCalledOnce();
     const unlinkedPath = unlinkSpy.mock.calls[0][0] as string;
@@ -210,7 +201,7 @@ describe('ideaCaptureHandler — photo messages', () => {
     mockFetch();
   });
 
-  it('7. Photo saved to permanent path (no temp file)', async () => {
+  it('6. Photo saved to permanent path (no temp file unlinked on success)', async () => {
     const { default: fsMock } = await import('node:fs/promises');
     const writeFileSpy = vi.mocked(fsMock.writeFile);
     const unlinkSpy = vi.mocked(fsMock.unlink);
@@ -228,20 +219,27 @@ describe('ideaCaptureHandler — photo messages', () => {
     });
 
     const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
+    await handler(ctx as never, TEST_GATEWAY_CTX);
 
-    // Photo written directly to permanent path — no unlink
+    // Photo written directly to permanent path — no unlink on success
     expect(unlinkSpy).not.toHaveBeenCalled();
-    const writtenPath = writeFileSpy.mock.calls[0][0] as string;
+    const photoWrite = writeFileSpy.mock.calls.find(([p]) =>
+      typeof p === 'string' && p.includes('idea-photo')
+    );
+    expect(photoWrite).toBeDefined();
+    const [writtenPath] = photoWrite as [string];
     expect(writtenPath).toMatch(/\/tmp\/ideas-photos\/idea-photo-[0-9a-f-]+\.jpg$/);
   });
 
-  it('8. Photo error reply sent and orphan cleaned up when appendFile fails', async () => {
+  it('7. Photo error reply sent and orphan cleaned up when writeFile (idea) fails', async () => {
     const { default: fsMock } = await import('node:fs/promises');
-    const appendSpy = vi.mocked(fsMock.appendFile);
+    const writeFileSpy = vi.mocked(fsMock.writeFile);
     const unlinkSpy = vi.mocked(fsMock.unlink);
 
-    appendSpy.mockRejectedValueOnce(new Error('disk full'));
+    // First writeFile (photo download) succeeds, second (idea file) fails
+    writeFileSpy
+      .mockResolvedValueOnce(undefined)   // photo download
+      .mockRejectedValueOnce(new Error('disk full'));  // idea file write
 
     const bot = makeBot();
     const ctx = makeCtx({
@@ -252,7 +250,7 @@ describe('ideaCaptureHandler — photo messages', () => {
     });
 
     const handler = createIdeaCaptureHandler(bot as never);
-    await handler(ctx as never);
+    await handler(ctx as never, TEST_GATEWAY_CTX);
 
     // Orphaned permanent photo file should be cleaned up on error
     expect(unlinkSpy).toHaveBeenCalledOnce();

--- a/test/handlers/narrator.test.ts
+++ b/test/handlers/narrator.test.ts
@@ -6,7 +6,6 @@ vi.mock('../../src/config.js', () => ({
   config: {
     telegramNarratorBotToken: 'test-token',
     narrator: {
-      allowedUserIds: new Set([1]),
       agentRunScript: '/fake/run.sh',
       narratorRoot: '/fake/claudes-world/agents/narrator',
       classifyModel: 'claude-haiku-4-5',


### PR DESCRIPTION
## Summary

- Adds `src/gateway/` module with `types.ts`, `match.ts`, `middleware.ts`, `dispatcher.ts` — all bot handlers now receive pre-gated context with zero auth boilerplate
- Introduces `agents/narrator/gateway.json` and `agents/idea-capture/gateway.json` declarative routing rules (chatType, userId, chatId, threadId, requireMention with AND+OR logic)
- Refactors `idea-capture.ts` to accept `gatewayCTX: { repo, folder }` and write per-file ideas to `captured-ideas/<folder>/YYYY-MM-DD-HH-MM-SS-<uuid>.md`
- Removes `NARRATOR_ALLOWED_USER_IDS`, `IDEA_ALLOWED_USER_IDS`, and `IDEA_FILE` env vars — access control lives in gateway.json files
- 3 new test files for gateway module (match, middleware, dispatcher) — 14 test files, 156 tests, all pass

Closes #66

## Test plan

- [x] `pnpm build` — TypeScript compiles clean
- [x] `pnpm test` — 156/156 tests pass (14 test files)
- [ ] Gateway middleware silently drops non-matching messages (no `next()` call)
- [ ] Idea files land at `captured-ideas/<folder>/YYYY-MM-DD-HH-MM-SS-<uuid>.md`
- [ ] Narrator bot still gated to DM + allowed user IDs via gateway.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)