### PR TITLE
feat(deploy): systemd user service + install.sh + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to dobot-server are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-22
+
+### Added
+
+- Initial shared Telegram bot server hosting `@narrator_dobot` (and `@idea_dobot` when `TELEGRAM_IDEA_BOT_TOKEN` is set).
+- `bot-factory` (grammY) so one process can host multiple `Bot` instances, each with its own handler wiring.
+- Handler modules:
+  - `narrator` — classify (Haiku subprocess) → tone/shape/length selection → claude-subprocess rewrite → delivery (md-speak TTS + shared link).
+  - `narrator-callback` — length-keyboard callback handler with timeout-rebuild on restart.
+  - `idea-capture` — per-folder idea capture with photo + URL + forwarded-message input.
+- Message input detection: text, photo, document, URL, forwarded messages.
+- CPC deep-link flow for idea_dobot pairing.
+- `router` / `dispatchMessage` for handler namespace dispatch within a bot.
+- `better-sqlite3` state layer with migrations:
+  - Pending narrator choices (length-keyboard awaiting input).
+  - Rate limiting counters (per-hour job cap, daily TTS spend cap).
+  - Jobs table with status tracking.
+- Startup sweep: reconciles abandoned pending state on boot.
+- `rebuildPendingTimeouts`: restores `setTimeout` handles for in-window pending choices that survived a restart.
+- Graceful shutdown: `SIGINT` + `SIGTERM` handlers with idempotent double-signal guard.
+- OTEL tracing via `@opentelemetry/sdk-trace-node` (ConsoleSpanExporter — OTLP follow-up tracked separately).
+- `withSpan(tracer, name, attrs, fn)` helper for consistent span wrapping.
+- `classify` prompt helper + `parsePrefix` for `[tone]` and `[tone:shape]` message prefixes.
+- Tone (10) and shape (6) skill files vendored under `agents/narrator/.claude/skills/`.
+- Path + URL validators with rate limits for untrusted input.
+- Vitest test suite: 131 tests across router, handlers, lib, and state modules.
+- systemd `--user` service (`systemd/user/dobot-server.service`) with journald logging.
+- Idempotent `install.sh`: pre-flight (linger + node + env file) → build → install unit → enable + start.
+- `README.md` Deploy section with install + log-tail + restart / stop commands.
+
+### Notes
+
+- Access control: per-bot allowlists configured via `*_ALLOWED_USER_IDS` env vars; a dedicated `gateway.json` layer is tracked separately (PR #67).
+- Logs: live tail via `journalctl --user -u dobot-server -f`.
+- Planned follow-ups (deferred, not in this release): OTLP exporter to local collector, `/healthz` HTTP endpoint + `sd_notify` watchdog, OTEL metrics alongside traces.
+
+[Unreleased]: https://github.com/claudes-world/dobot-server/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/claudes-world/dobot-server/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
 # dobot-server
-Unified Telegram bot server — narrator + idea_dobot + future bots via handler modules (grammY + TypeScript + SQLite)
+
+Unified Telegram bot server — narrator + idea_dobot + future bots via handler modules (grammY + TypeScript + SQLite).
+
+## Deploy
+
+Production deploy is a systemd `--user` service with journald logs.
+
+### First-time install
+
+```bash
+# 1. Create the env file with bot tokens
+mkdir -p ~/.secrets && chmod 0700 ~/.secrets
+cp .env.example ~/.secrets/dobot-server.env
+chmod 0600 ~/.secrets/dobot-server.env
+$EDITOR ~/.secrets/dobot-server.env   # fill in TELEGRAM_NARRATOR_BOT_TOKEN (+ optional TELEGRAM_IDEA_BOT_TOKEN)
+
+# 2. Enable linger so the service survives logout/reboot (one-time, needs sudo)
+sudo loginctl enable-linger $USER
+
+# 3. Run the installer (builds, installs unit, enables, starts)
+./install.sh
+```
+
+The installer is idempotent — safe to re-run after pulling updates.
+
+### Day-to-day
+
+```bash
+# Tail live logs
+journalctl --user -u dobot-server -f
+
+# Service status
+systemctl --user status dobot-server
+
+# Restart (after a code change + ./install.sh)
+systemctl --user restart dobot-server
+
+# Stop
+systemctl --user stop dobot-server
+```
+
+Historical logs are persisted by journald and accessible via:
+
+```bash
+journalctl --user -u dobot-server --since '1h ago'
+journalctl --user -u dobot-server --since today
+```
+
+## Development
+
+```bash
+pnpm install
+pnpm run build
+pnpm run test
+pnpm run start    # runs node dist/index.js with local .env
+```

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ fi
 # If both poll the same bot tokens, getUpdates returns HTTP 409 and SQLite write
 # contention corrupts state — halt with a clear message so the operator stops the
 # legacy process first.
-LEGACY_PIDS=$(pgrep -f "node .*dist/index\.js" | grep -v "$$" || true)
+LEGACY_PIDS=$(pgrep -f "node .*dist/index\.js" || true)
 SYSTEMD_PID=$(systemctl --user show dobot-server.service -p MainPID --value 2>/dev/null || echo 0)
 
 if [ -n "$LEGACY_PIDS" ] && [ "$SYSTEMD_PID" != "0" ]; then

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,26 @@ if ! test -e "/var/lib/systemd/linger/${USER}"; then
     exit 1
 fi
 
+# Detect legacy nohup/unmanaged `node dist/index.js` process running outside systemd
+# (historical deployment was `nohup node dist/index.js >> /tmp/dobot-server.log`).
+# If both poll the same bot tokens, getUpdates returns HTTP 409 and SQLite write
+# contention corrupts state — halt with a clear message so the operator stops the
+# legacy process first.
+LEGACY_PIDS=$(pgrep -f "node .*dist/index\.js" | grep -v "$$" || true)
+SYSTEMD_PID=$(systemctl --user show dobot-server.service -p MainPID --value 2>/dev/null || echo 0)
+
+if [ -n "$LEGACY_PIDS" ] && [ "$SYSTEMD_PID" != "0" ]; then
+    LEGACY_PIDS=$(echo "$LEGACY_PIDS" | grep -v "^${SYSTEMD_PID}$" || true)
+fi
+
+if [ -n "$LEGACY_PIDS" ]; then
+    echo "ERROR: Found existing unmanaged node dist/index.js process(es): $LEGACY_PIDS" >&2
+    echo "       Bot tokens would collide on getUpdates (HTTP 409) + duplicate message delivery." >&2
+    echo "       Stop the legacy process first: kill -TERM <PID>" >&2
+    echo "       Then re-run ./install.sh" >&2
+    exit 1
+fi
+
 if [ ! -x /usr/bin/node ]; then
     echo "ERROR: /usr/bin/node not found or not executable." >&2
     echo "The systemd unit hardcodes /usr/bin/node — install Node via the system package manager." >&2
@@ -44,6 +64,20 @@ if [ ! -e "$ENV_FILE" ]; then
     echo "ERROR: $ENV_FILE not found." >&2
     echo "Create it with TELEGRAM_NARRATOR_BOT_TOKEN and (optionally) TELEGRAM_IDEA_BOT_TOKEN." >&2
     echo "See .env.example for the full variable list." >&2
+    exit 1
+fi
+
+# Enforce secrets-file hygiene: 0600 perms (auto-tighten) + owner must match $USER.
+# Ownership drift is a red flag (cross-user contamination or root-owned file), mode
+# drift is a common config goof that's safe to auto-fix.
+PERMS=$(stat --format='%a' "$ENV_FILE")
+if [ "$PERMS" != "600" ]; then
+    echo "WARN: $ENV_FILE has permissions $PERMS (expected 600) — tightening to 0600" >&2
+    chmod 600 "$ENV_FILE"
+fi
+OWNER=$(stat --format='%U' "$ENV_FILE")
+if [ "$OWNER" != "$USER" ]; then
+    echo "ERROR: $ENV_FILE owned by '$OWNER' not '$USER' — refusing to use" >&2
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -34,22 +34,55 @@ if ! test -e "/var/lib/systemd/linger/${USER}"; then
     exit 1
 fi
 
-# Detect legacy nohup/unmanaged `node dist/index.js` process running outside systemd
-# (historical deployment was `nohup node dist/index.js >> /tmp/dobot-server.log`).
-# If both poll the same bot tokens, getUpdates returns HTTP 409 and SQLite write
-# contention corrupts state — halt with a clear message so the operator stops the
-# legacy process first.
-LEGACY_PIDS=$(pgrep -f "node .*dist/index\.js" || true)
+# Detect legacy nohup/unmanaged dobot-server process — any `node dist/index.js`
+# started outside systemd whose cwd is ~/code/dobot-server and whose exe is a
+# real node binary. Empirically narrow (R2 regex `node .*dist/index\.js` was too
+# permissive — matched CPC backends like `node apps/server/dist/index.js`, bash
+# wrappers whose argv contained the literal string, and Claude subagent prompts):
+#   1. Anchored argv: literal `node dist/index.js` (no `.*`) so longer paths miss
+#   2. /proc/PID/cwd == ~/code/dobot-server  (wrong-checkout guard)
+#   3. /proc/PID/exe resolves to a node binary (not a bash wrapper whose argv
+#      happens to contain the string)
+CANONICAL_DIR="$HOME/code/dobot-server"
 SYSTEMD_PID=$(systemctl --user show dobot-server.service -p MainPID --value 2>/dev/null || echo 0)
 
-if [ -n "$LEGACY_PIDS" ] && [ "$SYSTEMD_PID" != "0" ]; then
-    LEGACY_PIDS=$(echo "$LEGACY_PIDS" | grep -v "^${SYSTEMD_PID}$" || true)
-fi
+# pgrep -f is needed because node's comm is just `node` — argv holds the path.
+# Escape the dot so it's a literal (pgrep -f is ERE). The narrow pattern (no `.*`)
+# prevents matching `node apps/server/dist/index.js` or other alternate paths.
+CANDIDATE_PIDS=$(pgrep -af "node dist/index\.js" | awk '{print $1}' || true)
+
+LEGACY_PIDS=""
+for pid in $CANDIDATE_PIDS; do
+    # Skip systemd's own MainPID (we're checking for UNMANAGED duplicates)
+    if [ "$pid" = "$SYSTEMD_PID" ]; then
+        continue
+    fi
+    # Must be running from the canonical checkout
+    if [ ! -r "/proc/$pid/cwd" ]; then
+        continue
+    fi
+    CWD=$(readlink -f "/proc/$pid/cwd" 2>/dev/null || echo "")
+    if [ "$CWD" != "$CANONICAL_DIR" ]; then
+        continue
+    fi
+    # Must be an actual node binary — excludes bash wrappers whose argv contains
+    # the literal string `node dist/index.js` (e.g. Claude subagent shells, nohup
+    # invocation wrappers under PID 1).
+    EXE=$(readlink -f "/proc/$pid/exe" 2>/dev/null || echo "")
+    case "$EXE" in
+        */node|*/node[0-9]*|*/nodejs)
+            LEGACY_PIDS="$LEGACY_PIDS $pid"
+            ;;
+    esac
+done
+LEGACY_PIDS=$(echo "$LEGACY_PIDS" | xargs)  # trim whitespace
 
 if [ -n "$LEGACY_PIDS" ]; then
-    echo "ERROR: Found existing unmanaged node dist/index.js process(es): $LEGACY_PIDS" >&2
-    echo "       Bot tokens would collide on getUpdates (HTTP 409) + duplicate message delivery." >&2
-    echo "       Stop the legacy process first: kill -TERM <PID>" >&2
+    echo "ERROR: Found legacy unmanaged dobot-server node process(es) outside systemd:" >&2
+    echo "       PIDs: $LEGACY_PIDS" >&2
+    echo "       Each has CWD=$CANONICAL_DIR and exe=node, running dist/index.js." >&2
+    echo "       Bot tokens would collide on getUpdates (HTTP 409) + duplicate delivery." >&2
+    echo "       Stop the legacy process(es) first: kill -TERM $LEGACY_PIDS" >&2
     echo "       Then re-run ./install.sh" >&2
     exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# install.sh — deploy dobot-server as a systemd --user service with journald logs.
+#
+# Idempotent: safe to re-run. Does not overwrite user data or secrets.
+#
+# Pre-flight:
+#   - linger enabled for $USER (service must survive logout/reboot)
+#   - /usr/bin/node present
+#   - ~/.secrets/dobot-server.env present (bot tokens + DB path)
+#
+# Actions:
+#   1. pnpm install --frozen-lockfile
+#   2. pnpm run build
+#   3. copy systemd/user/dobot-server.service → ~/.config/systemd/user/
+#   4. systemctl --user daemon-reload
+#   5. systemctl --user enable dobot-server.service
+#   6. systemctl --user start OR restart (restart if already active, so re-runs
+#      after a rebuild pick up the new dist/)
+#   7. print status + tail command
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT_SRC="$SCRIPT_DIR/systemd/user/dobot-server.service"
+UNIT_DST_DIR="$HOME/.config/systemd/user"
+UNIT_DST="$UNIT_DST_DIR/dobot-server.service"
+ENV_FILE="$HOME/.secrets/dobot-server.env"
+
+# ---- Pre-flight ----
+
+if ! test -e "/var/lib/systemd/linger/${USER}"; then
+    echo "ERROR: linger not enabled for user '$USER'." >&2
+    echo "Run: sudo loginctl enable-linger $USER" >&2
+    exit 1
+fi
+
+if [ ! -x /usr/bin/node ]; then
+    echo "ERROR: /usr/bin/node not found or not executable." >&2
+    echo "The systemd unit hardcodes /usr/bin/node — install Node via the system package manager." >&2
+    exit 1
+fi
+
+if [ ! -e "$ENV_FILE" ]; then
+    echo "ERROR: $ENV_FILE not found." >&2
+    echo "Create it with TELEGRAM_NARRATOR_BOT_TOKEN and (optionally) TELEGRAM_IDEA_BOT_TOKEN." >&2
+    echo "See .env.example for the full variable list." >&2
+    exit 1
+fi
+
+if ! test -e "$UNIT_SRC"; then
+    echo "ERROR: $UNIT_SRC not found. Run install.sh from a dobot-server checkout." >&2
+    exit 1
+fi
+
+# ---- Build ----
+
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "ERROR: pnpm not found in PATH." >&2
+    exit 1
+fi
+
+cd "$SCRIPT_DIR"
+
+echo "==> pnpm install --frozen-lockfile"
+pnpm install --frozen-lockfile
+
+echo "==> pnpm run build"
+pnpm run build
+
+if [ ! -e "$SCRIPT_DIR/dist/index.js" ]; then
+    echo "ERROR: dist/index.js missing after build. Check pnpm run build output." >&2
+    exit 1
+fi
+
+# ---- Pre-install sanity: systemd unit targets ~/code/dobot-server ----
+# The unit hardcodes WorkingDirectory=%h/code/dobot-server. Warn loudly if install.sh
+# is being run from a different checkout — the built dist/ here won't be the one
+# that systemd launches. Fresh ~/code/dobot-server clones on this VPS are the happy path.
+CANONICAL_DIR="$HOME/code/dobot-server"
+if [ "$SCRIPT_DIR" != "$CANONICAL_DIR" ]; then
+    echo "WARN: install.sh is running from $SCRIPT_DIR" >&2
+    echo "      but the systemd unit's WorkingDirectory is $CANONICAL_DIR." >&2
+    echo "      systemd will run dist/index.js from $CANONICAL_DIR, not from here." >&2
+    echo "      If this is a worktree / non-canonical checkout, either symlink or" >&2
+    echo "      edit systemd/user/dobot-server.service before re-running." >&2
+fi
+
+# ---- Install unit ----
+
+mkdir -p "$UNIT_DST_DIR"
+cp "$UNIT_SRC" "$UNIT_DST"
+
+systemctl --user daemon-reload
+systemctl --user enable dobot-server.service
+
+# `enable --now` starts the service ONLY if it's inactive. For re-runs after a code
+# update (pnpm run build produced new dist/), we need an explicit restart so the
+# running process picks up the new compiled modules.
+if systemctl --user is-active --quiet dobot-server.service; then
+    systemctl --user restart dobot-server.service
+    echo "==> dobot-server.service was active — restarted to pick up new dist/."
+else
+    systemctl --user start dobot-server.service
+    echo "==> dobot-server.service started."
+fi
+
+# ---- Status ----
+
+echo ""
+systemctl --user status dobot-server.service --no-pager --lines=5 || true
+
+echo ""
+echo "Tail logs:    journalctl --user -u dobot-server -f"
+echo "Restart:      systemctl --user restart dobot-server"
+echo "Stop:         systemctl --user stop dobot-server"
+echo "Disable:      systemctl --user disable --now dobot-server"

--- a/systemd/user/dobot-server.service
+++ b/systemd/user/dobot-server.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=dobot-server — shared Telegram bot runtime
+Documentation=https://github.com/claudes-world/dobot-server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=NODE_ENV=production
+EnvironmentFile=%h/.secrets/dobot-server.env
+WorkingDirectory=%h/code/dobot-server
+ExecStart=/usr/bin/node dist/index.js
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=dobot-server
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Replaces the brittle `nohup node dist/index.js` deploy with a proper systemd `--user` service + journald logging. Also adds the project's first `CHANGELOG.md` and a `Deploy` section in the README.

Addresses gaps 1, 2, and 6 from the audit at `~/claudes-world/tmp/20260422-003910-dobot-server-audit.md`:

- **Gap 1 (HIGH)** — no systemd unit
- **Gap 2 (HIGH)** — logs written to `/tmp/dobot-server.log` (lost on reboot, no rotation)
- **Gap 6 (LOW but fragile)** — hardcoded `kill <stale-PID>` in the launcher bash one-liner

## Files

| File | Purpose |
|------|---------|
| `systemd/user/dobot-server.service` | systemd `--user` unit — `Restart=on-failure`, `StandardOutput=journal`, `EnvironmentFile=%h/.secrets/dobot-server.env`, `WorkingDirectory=%h/code/dobot-server` |
| `install.sh` | Idempotent installer: pre-flight (linger + node + env file) → `pnpm install --frozen-lockfile && pnpm run build` → copy unit → `daemon-reload` → `enable` → `start` or `restart` (restart-aware so re-runs after rebuild pick up new `dist/`) |
| `README.md` | Added `## Deploy` section — install, log tail (`journalctl --user -u dobot-server -f`), status, restart, stop |
| `CHANGELOG.md` | New (Keep-a-Changelog v1.1.0 format). `[0.1.0]` for current state. `[Unreleased]` header in place for future diffs. |

## Deferred (follow-up issues, NOT in this PR)

- **Gap 3** — OTLP exporter for OTEL spans (currently ConsoleSpanExporter spams journald)
- **Gap 4** — `/healthz` HTTP endpoint + `sd_notify` watchdog
- **Gap 5** — OTEL metrics alongside traces

## Constraints honored

- No `src/` changes.
- No new dependencies.
- No `agents/*/gateway.json` touched.
- Vitest: 131/131 passing on `dev` baseline + after.
- `tsc` clean.

## Pre-push review — local 3-tier swarm

Round 1 caught 2 must-fix items; both addressed before pushing:

- `install.sh` used `command -v /usr/bin/node` (unconventional for absolute-path checks) → now `[ -x /usr/bin/node ]`.
- `systemctl --user enable --now` no-ops if the service is already active, so a re-run after `pnpm run build` kept serving the old `dist/`. Now `install.sh` explicitly `restart`s if active, otherwise `start`s.

Additional hardening in the same round:
- `README.md` install steps create `~/.secrets/` (0700) before copying `dobot-server.env` (0600).
- `install.sh` warns loudly if run from a non-canonical `SCRIPT_DIR` since the unit's `WorkingDirectory` hardcodes `%h/code/dobot-server`.

Round 2: clean.

## Cutover plan (orchestrator-owned, not in this PR)

1. Merge this PR.
2. `systemctl --user stop` is a no-op since no unit exists yet → instead, `pkill -TERM -f "node dist/index.js"` scoped to the current nohup-launched PID (or `kill 1116399`).
3. From the canonical `~/code/dobot-server` checkout: `git pull origin dev && ./install.sh`.
4. Verify with `journalctl --user -u dobot-server -f` + a Telegram getMe ping.
5. Tag `v0.1.0` + `gh release create v0.1.0 --generate-notes`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>