### PR TITLE
feat(router): ignore edited_message with explicit log

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -8,6 +8,17 @@ export function registerHandlers(bot: Bot, handlers: {
   narratorCallback: Handler;
   cancel: Handler;
 }): void {
+  // bots using registerHandlers ignore edited_message — see issue #73
+  bot.on('edited_message', async (ctx) => {
+    try {
+      const msgId = ctx.editedMessage?.message_id;
+      console.debug(`[router] edited_message ignored (id: ${msgId})`);
+    } catch (err) {
+      console.error('edited_message handler threw', err);
+      // Do NOT re-throw — propagation would kill the bot loop
+    }
+  });
+
   // /cancel command — registered before generic message handler so it fires first
   bot.command('cancel', async (ctx) => {
     const tracer = getTracer('narrator');

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,19 +1,27 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { registerHandlers } from '../src/router.js';
 
-// Minimal grammY Bot fake — captures the registered 'message' handler
+// Minimal grammY Bot fake — captures registered handlers by event name
 function makeFakeBot() {
   let messageHandler: ((ctx: unknown) => Promise<void>) | null = null;
+  let editedMessageHandler: ((ctx: unknown) => Promise<void>) | null = null;
   const bot = {
     command: vi.fn(),
     on: (event: string, fn: (ctx: unknown) => Promise<void>) => {
       if (event === 'message') messageHandler = fn;
+      if (event === 'edited_message') editedMessageHandler = fn;
     },
     fire: async (ctx: unknown) => {
       if (messageHandler) await messageHandler(ctx);
     },
+    fireEdit: async (ctx: unknown) => {
+      if (editedMessageHandler) await editedMessageHandler(ctx);
+    },
   };
-  return bot as unknown as import('grammy').Bot & { fire: (ctx: unknown) => Promise<void> };
+  return bot as unknown as import('grammy').Bot & {
+    fire: (ctx: unknown) => Promise<void>;
+    fireEdit: (ctx: unknown) => Promise<void>;
+  };
 }
 
 function makeCtx(overrides: Record<string, unknown> = {}) {
@@ -121,5 +129,67 @@ describe('router crash boundary', () => {
     expect(exitSpy).not.toHaveBeenCalled();
 
     exitSpy.mockRestore();
+  });
+});
+
+describe('router edited_message handling', () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  it('registers an edited_message handler (not silently dropped at grammy level)', () => {
+    const handlers: string[] = [];
+    const bot = {
+      command: vi.fn(),
+      on: (event: string, _fn: unknown) => { handlers.push(event); },
+    } as unknown as import('grammy').Bot;
+    registerHandlers(bot, { narrator: vi.fn(), narratorCallback: vi.fn(), cancel: vi.fn() });
+    expect(handlers).toContain('edited_message');
+  });
+
+  it('logs ignore and does not call narrator handler on edited_message', async () => {
+    const bot = makeFakeBot();
+    const narrator = vi.fn();
+    registerHandlers(bot, { narrator, narratorCallback: vi.fn(), cancel: vi.fn() });
+
+    const editCtx = {
+      editedMessage: { message_id: 42, text: 'edited text' },
+    };
+    await bot.fireEdit(editCtx);
+
+    expect(narrator).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith('[router] edited_message ignored (id: 42)');
+  });
+
+  it('does not trigger narrator callback on edited_message', async () => {
+    const bot = makeFakeBot();
+    const narrator = vi.fn();
+    const narratorCallback = vi.fn();
+    registerHandlers(bot, { narrator, narratorCallback, cancel: vi.fn() });
+
+    const editCtx = {
+      editedMessage: { message_id: 99, text: 'updated idea' },
+    };
+    await bot.fireEdit(editCtx);
+
+    // Neither the narrator handler nor the callback should fire
+    expect(narrator).not.toHaveBeenCalled();
+    expect(narratorCallback).not.toHaveBeenCalled();
+  });
+
+  it('handles missing editedMessage gracefully', async () => {
+    const bot = makeFakeBot();
+    registerHandlers(bot, { narrator: vi.fn(), narratorCallback: vi.fn(), cancel: vi.fn() });
+
+    // editedMessage may be undefined in edge cases
+    const editCtx = { editedMessage: undefined };
+    await expect(bot.fireEdit(editCtx)).resolves.not.toThrow();
+    expect(debugSpy).toHaveBeenCalledWith('[router] edited_message ignored (id: undefined)');
   });
 });


### PR DESCRIPTION
## Summary

- Adds `bot.on('edited_message', ...)` in `registerHandlers` (`src/router.ts`) — logs a `debug` line and returns, consistent with the crash-boundary pattern used by all other handlers
- Semantics decision (per issue #73): **IGNORE** for all bots using `registerHandlers` — narrator already processed the original; idea-capture original is already written to disk
- Adds 4 tests in `test/router.test.ts` covering: handler registration at grammy level, narrator non-invocation, callback non-invocation, graceful undefined-editedMessage handling

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm test` — 181/181 pass (15 test files)
- [x] 3-tier local swarm CLEAN on `aaec118`:
  - Tier 1 (Claude subagent): NEEDS_FIXES → fixes applied (comment accuracy, test title, crash boundary)
  - Tier 2 (Codex): LOW finding (`sd-notify` was stale from wrong-branch diff — not present in actual diff)
  - Tier 3 (Gemini flash): CLEAN after fixes

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)