### PR TITLE
fix(systemd): StartLimitBurst + ExecStartPost healthz check (#26, #27)

### DIFF
--- a/systemd/user/dobot-server.service
+++ b/systemd/user/dobot-server.service
@@ -3,6 +3,8 @@ Description=dobot-server — shared Telegram bot runtime
 Documentation=https://github.com/claudes-world/dobot-server
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Service]
 Type=notify
@@ -11,6 +13,7 @@ Environment=NODE_ENV=production
 EnvironmentFile=%h/.secrets/dobot-server.env
 WorkingDirectory=%h/code/dobot-server
 ExecStart=/usr/bin/node dist/index.js
+ExecStartPost=%h/code/toolbox/lib/systemd-wait-port.sh 38801
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- Add `StartLimitIntervalSec=120` + `StartLimitBurst=5` so crash-loops flip to `failed` state
- Add `ExecStartPost` healthz port 38801 verification via shared toolbox helper

Part of claudes-world/do-box#26 + claudes-world/do-box#27 (umbrella).

## Test plan
- [ ] `systemd-analyze verify` on modified unit (if dobot-server installed)
- [ ] Confirm `Type=notify` + `ExecStartPost` coexist correctly (ExecStartPost runs after READY=1 signal, belt-and-suspenders)

## Swarm review (round 1 — pre-push)

Local 3-tier swarm result: **CLEAN** (no findings)

- Tier 1 (Claude subagent): CLEAN — confirmed `StartLimit*` in `[Unit]` correct for systemd v240+, `ExecStartPost` gated on `READY=1` for `Type=notify`, no deadlock possible
- Tier 2 (Codex CLI): confirmed man page facts (output truncated, no findings produced)
- Tier 3 (Gemini): CLEAN — confirmed `[Unit]` placement modern/correct, ExecStartPost semantics sound, port 38801 consistent with ADR 0003

#swarm-reviewed