### PR TITLE
fix(narrator): undici@8 fetch compat

### DIFF
--- a/src/lib/url-validator.ts
+++ b/src/lib/url-validator.ts
@@ -1,6 +1,6 @@
 import dns from 'node:dns/promises';
 import ipaddr from 'ipaddr.js';
-import { Agent as UndiciAgent } from 'undici';
+import { Agent as UndiciAgent, fetch, type Response as UndiciResponse } from 'undici';
 import he from 'he';
 
 const ALLOWED_CONTENT_TYPES = ["text/html", "text/markdown", "text/plain"];
@@ -107,7 +107,7 @@ export async function validateAndFetchUrl(urlString: string): Promise<string> {
 
   let currentUrl = url.toString();
   let redirectCount = 0;
-  let response: Response;
+  let response: UndiciResponse;
 
   try {
     // lastDispatcher holds the dispatcher for the final (non-redirect) hop.
@@ -121,9 +121,10 @@ export async function validateAndFetchUrl(urlString: string): Promise<string> {
         const hopUrl = new URL(currentUrl);
         const resolvedIp = await resolveAndValidate(hopUrl.hostname);
 
-        // Pin the pre-resolved IP at socket level — undici will not re-resolve the hostname
+        // Pin the pre-resolved IP at socket level — undici will not re-resolve the hostname.
+        // undici 8.x changed the lookup callback contract to cb(null, [{ address, family }]).
         const dispatcher = new UndiciAgent({
-          connect: { lookup: (_hostname: string, _opts: unknown, cb: (err: Error | null, address: string, family: number) => void) => cb(null, resolvedIp, 4) }
+          connect: { lookup: (_hostname: string, _opts: unknown, cb: (err: Error | null, addresses: Array<{ address: string; family: number }>) => void) => cb(null, [{ address: resolvedIp, family: 4 }]) }
         });
 
         let isRedirect = false;
@@ -131,7 +132,6 @@ export async function validateAndFetchUrl(urlString: string): Promise<string> {
           response = await fetch(hopUrl.toString(), {
             signal: controller.signal,
             redirect: 'manual',
-            // @ts-expect-error — undici dispatcher is not in the standard fetch types but is supported by Node.js
             dispatcher,
           });
 

--- a/test/lib/url-validator.test.ts
+++ b/test/lib/url-validator.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { validateAndFetchUrl } from '../../src/lib/url-validator.js';
 
 // Mock dns/promises module
 vi.mock('node:dns/promises', () => ({
@@ -8,8 +7,22 @@ vi.mock('node:dns/promises', () => ({
   },
 }));
 
+// Mock undici — url-validator imports `fetch` from 'undici' so global stubGlobal
+// won't intercept calls. We mock the named export here. Agent is preserved as a
+// no-op constructor since the dispatcher is only used by fetch (which is mocked).
+vi.mock('undici', () => ({
+  Agent: class {
+    destroy() { return Promise.resolve(); }
+  },
+  fetch: vi.fn(),
+}));
+
 import dns from 'node:dns/promises';
+import { fetch as undiciFetch } from 'undici';
 const mockDnsLookup = dns.lookup as ReturnType<typeof vi.fn>;
+const mockUndiciFetch = undiciFetch as unknown as ReturnType<typeof vi.fn>;
+
+import { validateAndFetchUrl } from '../../src/lib/url-validator.js';
 
 // Helper to build a minimal Response-like object
 function makeResponse(opts: {
@@ -34,17 +47,15 @@ function makeResponse(opts: {
   return new Response(stream, { status, headers: headerMap });
 }
 
-// Stub global fetch
-let fetchStub: ReturnType<typeof vi.fn>;
+// Reference the mocked undici fetch
+const fetchStub = mockUndiciFetch;
 
 beforeEach(() => {
-  fetchStub = vi.fn();
-  vi.stubGlobal('fetch', fetchStub);
+  fetchStub.mockReset();
   mockDnsLookup.mockReset();
 });
 
 afterEach(() => {
-  vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
 


### PR DESCRIPTION
## Summary

Hot-fix for narrator URL fetch failure reported at 21:07 ET 2026-04-25. Liam fed a GitHub URL and got `TypeError: fetch failed`.

## Root cause (empirically verified)

`undici@8.1.0` (current pin) has two incompatibilities with Node v24.13.1:

1. **Global `fetch()` rejects undici@8 dispatcher.** Passing `dispatcher: new Agent({...})` to Node's global fetch throws `invalid onRequestStart method` — the global integration is out of sync with undici@8's Agent contract.
2. **`connect.lookup` callback shape changed in undici 8.x.** OLD (Node-native): `cb(null, address, family)`. NEW (undici 8.x): `cb(null, [{ address, family }])`. The old shape silently fails to pin the IP, defeating the DNS-rebinding guard.

## Fix

In `src/lib/url-validator.ts`:
- Import and use undici's own `fetch` named export (matches Agent contract).
- Emit the new lookup callback shape: `cb(null, [{ address: resolvedIp, family: 4 }])`.
- Type `response` as undici `Response` (lib.dom vs undici stream-type mismatch on `body.getReader`).
- Remove now-unnecessary `@ts-expect-error` on `dispatcher` (undici's `RequestInit` declares it).

In `test/lib/url-validator.test.ts`:
- Replace `vi.stubGlobal('fetch', fetchStub)` with `vi.mock('undici', ...)` so the production import path is correctly intercepted.

## Empirical evidence

```js
// Smoke test — passes only with both fixes applied:
const { Agent, fetch } = require("undici");
const dispatcher = new Agent({ connect: { lookup: (h, o, cb) =>
  cb(null, [{ address: "140.82.121.3", family: 4 }]) } });
const r = await fetch("https://github.com/...", { dispatcher });
// r.status === 200
```

End-to-end with the patched function:

```
$ node -e "import('./dist/lib/url-validator.js').then(({validateAndFetchUrl}) =>
   validateAndFetchUrl('https://github.com/claudes-world/dobot-server')
   .then(t => console.log('len=' + t.length)))"
len=8173
```

## Test plan

- [x] `pnpm build` — clean (no TS errors)
- [x] `pnpm test` — 192/192 pass (16 url-validator tests included; updated to mock undici directly)
- [x] Live URL fetch end-to-end — GitHub URL returns stripped HTML body
- [x] Local swarm review (codex + gemini): codex CLEAN, gemini findings all false-positives (misread existing dispatcher-cleanup + IPv4-pinned DNS resolution)

## Constraints honored

- undici version unchanged (still `^8.1.0`)
- No new tests added (existing `url-validator.test.ts` updated to keep coverage)
- Single-app repo paths (`src/lib/`, `test/lib/`)